### PR TITLE
Support for all exports

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -83,7 +83,8 @@ class Panoptes(object):
         params={},
         headers={},
         json={},
-        etag=None
+        etag=None,
+        endpoint=None
     ):
         _headers = self._http_headers['default'].copy()
         _headers.update(self._http_headers[method])
@@ -102,7 +103,7 @@ class Panoptes(object):
                 'If-Match': etag,
             })
 
-        url = self.endpoint + '/api' + path
+        url = (endpoint or self.endpoint) + '/api' + path
         response = self.session.request(
             method,
             url,
@@ -125,9 +126,18 @@ class Panoptes(object):
         params={},
         headers={},
         json={},
-        etag=None
+        etag=None,
+        endpoint=None
     ):
-        response = self.http_request(method, path, params, headers, json, etag)
+        response = self.http_request(
+            method,
+            path,
+            params,
+            headers,
+            json,
+            etag,
+            endpoint
+        )
         if (
             response.status_code == 204 or
             int(response.headers.get('Content-Length', -1)) == 0 or
@@ -144,57 +154,137 @@ class Panoptes(object):
                 ))
         return (json_response, response.headers.get('ETag'))
 
-    def get_request(self, path, params={}, headers={}):
-        return self.http_request('GET', path, params, headers)
+    def get_request(self, path, params={}, headers={}, endpoint=None):
+        return self.http_request(
+            'GET',
+            path,
+            params=params,
+            headers=headers,
+            endpoint=endpoint
+        )
 
-    def get(self, path, params={}, headers={}):
-        return self.json_request('GET', path, params, headers)
+    def get(self, path, params={}, headers={}, endpoint=None):
+        return self.json_request(
+            'GET',
+            path,
+            params=params,
+            headers=headers,
+            endpoint=endpoint
+        )
 
-    def put_request(self, path, params={}, headers={}, json={}, etag=None):
+    def put_request(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
         return self.http_request(
             'PUT',
             path,
-            params,
-            headers,
+            params=params,
+            headers=headers,
             json=json,
-            etag=etag
+            etag=etag,
+            endpoint=None
         )
 
-    def put(self, path, params={}, headers={}, json={}, etag=None):
+    def put(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
         return self.json_request(
             'PUT',
             path,
-            params,
-            headers,
+            params=params,
+            headers=headers,
             json=json,
-            etag=etag
+            etag=etag,
+            endpoint=endpoint
         )
 
-    def post_request(self, path, params={}, headers={}, json={}, etag=None):
+    def post_request(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
         return self.http_request(
             'post',
             path,
             params=params,
             headers=headers,
             json=json,
-            etag=etag
+            etag=etag,
+            endpoint=endpoint
         )
 
-    def post(self, path, params={}, headers={}, json={}, etag=None):
-        return self.json_request('POST', path, params, headers, json, etag)
+    def post(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
+        return self.json_request(
+            'POST',
+            path,
+            params=params,
+            headers=headers,
+            json=json,
+            etag=etag,
+            endpoint=endpoint
+        )
 
-    def delete_request(self, path, params={}, headers={}, json={}, etag=None):
+    def delete_request(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
         return self.http_request(
             'delete',
             path,
             params=params,
             headers=headers,
             json=json,
-            etag=etag
+            etag=etag,
+            endpoint=None
         )
 
-    def delete(self, path, params={}, headers={}, json={}, etag=None):
-        return self.json_request('DELETE', path, params, headers, json, etag)
+    def delete(
+        self,
+        path,
+        params={},
+        headers={},
+        json={},
+        etag=None,
+        endpoint=None
+    ):
+        return self.json_request(
+            'DELETE',
+            path,
+            params=params,
+            headers=headers,
+            json=json,
+            etag=etag,
+            endpoint=endpoint
+        )
 
     def login(self, username=None, password=None):
         if not username:

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -6,6 +6,12 @@ from panoptes_client.panoptes import (
     LinkResolver, PanoptesAPIException, PanoptesObject
 )
 
+TALK_EXPORT_TYPES = (
+    'talk_comments',
+    'talk_tags',
+)
+
+
 class Project(PanoptesObject):
     _api_slug = 'projects'
     _link_slug = 'project'
@@ -24,33 +30,45 @@ class Project(PanoptesObject):
             return None
         return cls.where(id=id, slug=slug).next()
 
-    def get_classifications_export(
+    def get_export(
         self,
+        export_type,
         generate=False,
         wait=False,
         wait_timeout=60
     ):
+        if export_type in TALK_EXPORT_TYPES:
+            return self._get_talk_export(
+                export_type,
+                generate,
+                wait,
+                wait_timeout
+            )
+
         if generate:
-            self.generate_classifications_export()
+            self.generate_export(export_type)
 
         if generate or wait:
-            export = self.wait_classifications_export(wait_timeout)
+            export = self.wait_export(export_type, wait_timeout)
         else:
-            export = self.describe_classifications_export()
+            export = self.describe_export(export_type)
 
         return requests.get(
             export['media'][0]['src'],
             stream=True
         )
 
-    def wait_classifications_export(self, timeout=60):
+    def wait_export(self, export_type, timeout=60):
+        if export_type in TALK_EXPORT_TYPES:
+            return self._wait_talk_export(export_type, timeout)
+
         success = False
         end_time = datetime.datetime.now() + datetime.timedelta(
             seconds=timeout
         )
 
         while datetime.datetime.now() < end_time:
-            export_description = self.describe_classifications_export()
+            export_description = self.describe_export(export_type)
             if export_description:
                 export_metadata = export_description['media'][0]['metadata']
                 if export_metadata.get('state', '') == 'ready':
@@ -60,23 +78,48 @@ class Project(PanoptesObject):
 
         if not success:
             raise PanoptesAPIException(
-                'classifications_export not ready within {} seconds'.format(
+                '{}_export not ready within {} seconds'.format(
+                    export_type,
                     timeout
                 )
             )
 
         return export_description
 
-    def generate_classifications_export(self):
+    def generate_export(self, export_type):
+        if export_type in TALK_EXPORT_TYPES:
+            return self._generate_talk_export(export_type)
+
         return Project.post(
-            self._classifications_export_path(),
+            self._export_path(export_type),
             json = {"media":{"content_type":"text/csv"}}
         )[0]
 
-    def describe_classifications_export(self):
-        return Project.get(self._classifications_export_path())[0]
+    def describe_export(self, export_type):
+        if export_type in TALK_EXPORT_TYPES:
+            return self._describe_talk_export(export_type)
 
-    def _classifications_export_path(self):
-        return '{}/classifications_export'.format(self.id)
+        return Project.get(self._export_path(export_type))[0]
+
+    def _get_talk_export(
+        self,
+        export_type,
+        generate,
+        wait,
+        wait_timeout
+    ):
+        raise NotImplementedError('Talk exports are not yet supported')
+
+    def _wait_talk_export(self, export_type, timeout):
+        raise NotImplementedError('Talk exports are not yet supported')
+
+    def _generate_talk_export(self, export_type):
+        raise NotImplementedError('Talk exports are not yet supported')
+
+    def _describe_talk_export(self, export_type):
+        raise NotImplementedError('Talk exports are not yet supported')
+
+    def _export_path(self, export_type):
+        return '{}/{}_export'.format(export_type, self.id)
 
 LinkResolver.register(Project)


### PR DESCRIPTION
Talk exports still not supported. They'll come soon -- I'm intending to abstract away the fact that Talk exports work differently to the others, so it'll work like the following:

```python
project = Project(...)
project.get_export('classifications')
project.get_export('subjects')
project.get_export('talk_comments')
# and so on
```