### PR TITLE
Project owners can update ProjectPreference settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,15 @@ subject.save()
 # SubjectSet.add() can take a list of Subjects, or just one.
 subject_set.add(subject)
 ```
+
+Project owners with client credentials can update their users' project settings (workflow_id only):
+
+```python
+from panoptes_client import Panoptes, User, Subject, ProjectPreferences
+Panoptes.connect(client_id="example",client_secret="example")
+user = User.find("1234")
+project = Project.find("1234")
+project_prefs = ProjectPreferences.find(user=user,project=project)
+settings = {"workflow_id": "1234"}
+pp.update_settings(settings)
+```

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ user = User.find("1234")
 project = Project.find("1234")
 project_prefs = ProjectPreferences.find(user=user,project=project)
 settings = {"workflow_id": "1234"}
-pp.update_settings(settings)
+pp.save_settings(settings)
 ```

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -1,7 +1,6 @@
 import requests
 import os
 
-
 from datetime import datetime, timedelta
 
 class Panoptes(object):
@@ -404,6 +403,15 @@ class PanoptesObject(object):
     @classmethod
     def post(cls, path, params={}, headers={}, json={}):
         return Panoptes.client().post(
+            cls.url(path),
+            params,
+            headers,
+            json
+        )
+
+    @classmethod
+    def put(cls, path, params={}, headers={}, json={}):
+        return Panoptes.client().put(
             cls.url(path),
             params,
             headers,

--- a/panoptes_client/project_preferences.py
+++ b/panoptes_client/project_preferences.py
@@ -32,15 +32,20 @@ class ProjectPreferences(PanoptesObject):
             id = cls.where(user_id=_user_id, project_id=_project_id).next().id
         return super(ProjectPreferences, cls).find(id)
 
-    def update_settings(self, settings):
+    def save_settings(self, settings, update=True):
         if (isinstance(settings, dict)):
+            if update:
+                to_update = self.settings
+                to_update.update(settings)
+            else:
+                to_update = settings
             self.put(
                 'update_settings',
                 json={
                     'project_preferences': {
                         'user_id': self.links.raw['user'],
                         'project_id': self.links.raw['project'],
-                        'settings': settings,
+                        'settings': to_update,
                     }
                 }
             )

--- a/panoptes_client/project_preferences.py
+++ b/panoptes_client/project_preferences.py
@@ -7,6 +7,7 @@ class ProjectPreferences(PanoptesObject):
     _link_slug = 'project_preferences'
     _edit_attributes = (
         'preferences',
+        'settings',
     )
 
     @classmethod
@@ -30,5 +31,21 @@ class ProjectPreferences(PanoptesObject):
                 raise TypeError
             id = cls.where(user_id=_user_id, project_id=_project_id).next().id
         return super(ProjectPreferences, cls).find(id)
+
+    def update_settings(self, settings):
+        if (isinstance(settings, dict)):
+            self.put(
+                'update_settings',
+                json={
+                    'project_preferences': {
+                        'user_id': self.links.raw['user'],
+                        'project_id': self.links.raw['project'],
+                        'settings': settings,
+                    }
+                }
+            )
+            self.reload()
+        else:
+            raise TypeError
 
 LinkResolver.register(ProjectPreferences)


### PR DESCRIPTION
A project owner can update the "settings" attribute of ProjectPreferences. #save() doesn't work here because they won't have permission to update anything else, so I added a method.