### PR TITLE
Specify minimum requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'requests',
+        'requests>=2.4.2',
     ],
 )


### PR DESCRIPTION
Earlier versions don't support the `json` request parameter