### PR TITLE
Flipped sign on expiration check

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -339,7 +339,7 @@ class Panoptes(object):
         return self.session.get(url, headers=headers).headers['x-csrf-token']
 
     def get_bearer_token(self):
-        if not self.bearer_token or self.bearer_expires > datetime.now():
+        if not self.bearer_token or self.bearer_expires < datetime.now():
             grant_type = 'password'
 
             if self.client_secret:


### PR DESCRIPTION
```if not self.bearer_token or self.bearer_expires > datetime.now():```

would always evaluate True on the second part because the `not` doesn't apply to both. Flipped the sign so that this if statement evaluates true if there is no bearer token or if it is expired.

