### PR TITLE
Set member subject resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ List the subjects in a subject_set:
 ```python
 subject_set=SubjectSet.find(1234)
 
+# via SetMemberSubject link resource
+# Fast and returns the subject id string only
+for sms in subject_set.set_member_subjects():
+    print("%s," % (sms.subject_id()))
+
+# Not as fast but returns the linked subject resource
+for sms in subject_set.set_member_subjects():
+    print("%s," % (sms.links.subject))
+
+# via the SubjectSet : Subject links
+# Slow but returns the subject resource
 for subject in subject_set.subjects():
     print("%s," % (subject.id))
 ```

--- a/panoptes_client/__init__.py
+++ b/panoptes_client/__init__.py
@@ -6,3 +6,4 @@ from panoptes_client.workflow import Workflow
 from panoptes_client.classification import Classification
 from panoptes_client.project_preferences import ProjectPreferences
 from panoptes_client.user import User
+from panoptes_client.set_member_subject import SetMemberSubject

--- a/panoptes_client/set_member_subject.py
+++ b/panoptes_client/set_member_subject.py
@@ -1,0 +1,15 @@
+from panoptes_client.panoptes import PanoptesObject, LinkResolver
+
+class SetMemberSubject(PanoptesObject):
+    _api_slug = 'set_member_subjects'
+    _link_slug = 'set_member_subjects'
+    _edit_attributes = ()
+
+    def subject_set_id(self):
+        return self.raw['links']['subject_set']
+
+    def subject_id(self):
+        return self.raw['links']['subject']
+
+LinkResolver.register(SetMemberSubject)
+LinkResolver.register(SetMemberSubject, 'set_member_subject')

--- a/panoptes_client/set_member_subject.py
+++ b/panoptes_client/set_member_subject.py
@@ -1,5 +1,6 @@
 from panoptes_client.panoptes import PanoptesObject, LinkResolver
 
+
 class SetMemberSubject(PanoptesObject):
     _api_slug = 'set_member_subjects'
     _link_slug = 'set_member_subjects'

--- a/panoptes_client/subject_set.py
+++ b/panoptes_client/subject_set.py
@@ -1,5 +1,6 @@
 from panoptes_client.panoptes import PanoptesObject, LinkResolver
 from panoptes_client.subject import Subject
+from panoptes_client.set_member_subject import SetMemberSubject
 
 
 class SubjectSet(PanoptesObject):
@@ -19,6 +20,9 @@ class SubjectSet(PanoptesObject):
 
     def subjects(self):
         return Subject.where(subject_set_id=self.id)
+
+    def set_member_subjects(self):
+        return SetMemberSubject.where(subject_set_id=self.id)
 
     # Add or remove subject links.
     # Takes a tuple or list of Subject objects

--- a/panoptes_client/tests/test_set_member_subject.py
+++ b/panoptes_client/tests/test_set_member_subject.py
@@ -1,7 +1,7 @@
 import unittest
 
 from panoptes_client import SetMemberSubject
-from panoptes_client.panoptes import PanoptesAPIException
+
 
 class TestSetMemberSubject(unittest.TestCase):
     def test_find_id(self):

--- a/panoptes_client/tests/test_set_member_subject.py
+++ b/panoptes_client/tests/test_set_member_subject.py
@@ -1,0 +1,17 @@
+import unittest
+
+from panoptes_client import SetMemberSubject
+from panoptes_client.panoptes import PanoptesAPIException
+
+class TestSetMemberSubject(unittest.TestCase):
+    def test_find_id(self):
+        sms = SetMemberSubject.find(1000)
+        self.assertEqual(sms.id, '1000')
+
+    def test_subject_set_id(self):
+        sms = SetMemberSubject.find(1000)
+        self.assertEqual(sms.subject_set_id(), '2')
+
+    def test_subject_id(self):
+        sms = SetMemberSubject.find(1000)
+        self.assertEqual(sms.subject_id(), '1458')


### PR DESCRIPTION
Provide a resource for the link between subject set and subjects and allow SubjectSet to return these linked resources.

Use the faster sms lookups for determining subject : set membership. E.g.

```
subject_set=SubjectSet.find(1)

for sms in subject_set.set_member_subjects():
    print("%s," % (sms.subject_id()))
```