### PR TITLE
Add Project.collaborators() and ProjectRole

### DIFF
--- a/panoptes_client/__init__.py
+++ b/panoptes_client/__init__.py
@@ -5,4 +5,5 @@ from panoptes_client.subject_set import SubjectSet
 from panoptes_client.workflow import Workflow
 from panoptes_client.classification import Classification
 from panoptes_client.project_preferences import ProjectPreferences
+from panoptes_client.project_role import ProjectRole
 from panoptes_client.user import User

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -605,6 +605,8 @@ class LinkResolver(object):
         linked_object = self.raw[name]
         if type(linked_object) == list:
             return map(lambda o: object_class.find(o), linked_object)
+        if type(linked_object) == dict and 'id' in linked_object:
+            return object_class.find(linked_object['id'])
         else:
             return object_class.find(linked_object)
 

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -3,8 +3,13 @@ import requests
 import time
 
 from panoptes_client.panoptes import (
-    LinkResolver, PanoptesAPIException, PanoptesObject, Talk
+    LinkResolver,
+    PanoptesAPIException,
+    PanoptesObject,
+    Talk
 )
+
+from panoptes_client.project_role import ProjectRole
 
 TALK_EXPORT_TYPES = (
     'talk_comments',
@@ -113,5 +118,12 @@ class Project(PanoptesObject):
 
     def _export_path(self, export_type):
         return '{}/{}_export'.format(self.id, export_type)
+
+    def collaborators(self, *roles):
+        return [
+            r.links.owner for r in ProjectRole.where(project_id=self.id)
+            if len(roles) == 0 or len(set(roles) & set(r.roles)) > 0
+        ]
+
 
 LinkResolver.register(Project)

--- a/panoptes_client/project_role.py
+++ b/panoptes_client/project_role.py
@@ -1,0 +1,9 @@
+from panoptes_client.panoptes import PanoptesObject, LinkResolver
+
+
+class ProjectRole(PanoptesObject):
+    _api_slug = 'project_roles'
+    _link_slug = 'project_roles'
+    _edit_attributes = ()
+
+LinkResolver.register(ProjectRole)

--- a/panoptes_client/user.py
+++ b/panoptes_client/user.py
@@ -7,3 +7,4 @@ class User(PanoptesObject):
     _edit_attributes = ()
 
 LinkResolver.register(User)
+LinkResolver.register(User, 'owner')


### PR DESCRIPTION
Example usage:

```python
>>> from panoptes_client import Project
>>> p = Project.find(slug='zooniverse/shakespeares-world')
>>> p.collaborators()
[<User 7>, <User 299778>, <User 245>, <User 10>, <User 1490760>, <User 321028>, <User 352990>, <User 1412010>, <User 1414358>, <User 828029>, <User 1410251>, <User 1410955>, <User 255>, <User 246>, <User 1813>, <User 1370867>, <User 1395487>, <User 219>, <User 1405910>, <User 6>, <User 1404044>, <User 322786>, <User 1>]
>>> p.collaborators('owner')
[<User 1>]
>>> p.collaborators('expert')
[<User 1414358>, <User 1410251>, <User 1410955>, <User 1370867>, <User 1395487>]
>>> p.collaborators('owner', 'expert')
[<User 1414358>, <User 1410251>, <User 1410955>, <User 1370867>, <User 1395487>, <User 1>]
```