### PR TITLE
Support for adding subjectsets to workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ subject_set.add([subject1, subject2, subject3])
 # or just one at a time (but this is slower than doing several together)
 subject_set.add(subject1)
 subject_set.add(subject2)
+
+# add subject set to 1st workflow in project
+workflow = project.links.workflows[0]
+workflow.add_subject_sets([subject_set]) 
 ```
 
 List the subjects in a subject_set:

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -32,7 +32,7 @@ class Workflow(PanoptesObject, Exportable):
     def add_subject_sets(self, subject_sets):
         _subject_sets = self._build_subject_set_list(subject_sets)
 
-        self.post(
+        return Workflow.http_post(
             '{}/links/subject_sets'.format(self.id),
             json={'subject_sets': _subject_sets}
         )


### PR DESCRIPTION
I've updated the python client and docs/readme so workflows can have subjectsets linked to them.