### PR TITLE
Fix: Return a list of linked objects instead of a map

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -612,7 +612,7 @@ class LinkResolver(object):
         object_class = LinkResolver.types.get(name)
         linked_object = self.raw[name]
         if type(linked_object) == list:
-            return map(lambda o: object_class.find(o), linked_object)
+            return [object_class.find(o) for o in linked_object]
         if type(linked_object) == dict and 'id' in linked_object:
             return object_class.find(linked_object['id'])
         else:


### PR DESCRIPTION
The behaviour of map is different in Python 3