### PR TITLE
Add Workflow versions

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,6 +2,10 @@ FROM python:3
 
 WORKDIR /usr/src/panoptes-python-client
 
-COPY . /usr/src/panoptes-python-client
+COPY setup.py .
 
 RUN pip install .
+
+COPY . .
+
+RUN pip install -U .

--- a/Dockerfile.dev2
+++ b/Dockerfile.dev2
@@ -2,6 +2,10 @@ FROM python:2.7
 
 WORKDIR /usr/src/panoptes-python-client
 
-COPY . /usr/src/panoptes-python-client
+COPY setup.py .
 
 RUN pip install .
+
+COPY . .
+
+RUN pip install -U .

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -638,8 +638,15 @@ class LinkResolver(object):
         if not self.parent._loaded:
             self.parent.reload()
 
-        object_class = LinkResolver.types.get(name)
         linked_object = self.parent.raw['links'][name]
+        object_class = LinkResolver.types.get(name)
+        if (
+            not object_class and
+            type(linked_object == dict) and
+            'type' in linked_object
+        ):
+            object_class = LinkResolver.types.get(linked_object['type'])
+
 
         if type(linked_object) == list:
             return [object_class(_id) for _id in linked_object]

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -67,5 +67,10 @@ class Workflow(PanoptesObject, Exportable):
 
         return _subject_sets
 
+    @property
+    def versions(self):
+        return WorkflowVersion.where(workflow=self)
 
 LinkResolver.register(Workflow)
+
+from panoptes_client.workflow_version import WorkflowVersion

--- a/panoptes_client/workflow_version.py
+++ b/panoptes_client/workflow_version.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, division, print_function
-from builtins import str
 
-from panoptes_client.panoptes import Panoptes, PanoptesObject
+from panoptes_client.panoptes import (
+    Panoptes,
+    PanoptesAPIException,
+    PanoptesObject,
+)
 from panoptes_client.workflow import Workflow
+
 
 class WorkflowVersion(PanoptesObject):
     _api_slug = 'versions'
@@ -16,6 +20,15 @@ class WorkflowVersion(PanoptesObject):
             params,
             headers,
         )
+
+    @classmethod
+    def find(cls, _id, workflow):
+        try:
+            return cls.where(id=_id, workflow=workflow).next()
+        except StopIteration:
+            raise PanoptesAPIException(
+                "Could not find {} with id='{}'".format(cls.__name__, _id)
+            )
 
     def save(self):
         raise NotImplementedError(

--- a/panoptes_client/workflow_version.py
+++ b/panoptes_client/workflow_version.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, division, print_function
+from builtins import str
+
+from panoptes_client.panoptes import Panoptes, PanoptesObject
+from panoptes_client.workflow import Workflow
+
+class WorkflowVersion(PanoptesObject):
+    _api_slug = 'versions'
+    _edit_attributes = tuple()
+
+    @classmethod
+    def http_get(cls, path, params={}, headers={}):
+        workflow = params.pop('workflow')
+        return Panoptes.client().get(
+            Workflow.url(workflow.id) + cls.url(path),
+            params,
+            headers,
+        )
+
+    def save(self):
+        raise NotImplementedError(
+            'It is not possible to manually create workflow versions. '
+            'Modify the workflow instead.'
+        )
+
+    @property
+    def workflow(self):
+        return self.links.item


### PR DESCRIPTION
Adds a `Workflow.versions` property. Example usage:

```python
>>> from panoptes_client import Workflow
>>> w = Workflow(43)
>>> v = list(w.versions)
>>> v[0].workflow
<Workflow 43>
>>> v[0].changeset
{'tasks': [{'T1': {'help': 'T1.help', 'type': 'drawing', 'tools': [{'type': 'point', 'color': '#00ff00', 'label': 'T1.tools.0.label', 'details': []}], 'instruction': 'T1.instruction'}, 'T2': {'help': 'T2.help', 'type': 'single', 'answers': [], 'question': 'T2.question'}, 'T3': {'type': 'survey', 'images': {}, 'choices': {}, 'questions': {}, 'choicesOrder': [], 'questionsOrder': [], 'characteristics': {}, 'characteristicsOrder': []}}, {'T1': {'help': 'T1.help', 'type': 'drawing', 'tools': [{'type': 'point', 'color': '#00ff00', 'label': 'T1.tools.0.label', 'details': []}], 'instruction': 'T1.instruction'}, 'T2': {'help': 'T2.help', 'type': 'single', 'answers': [], 'question': 'T2.question'}}]}
```

Closes #92 