### PR TITLE
avoid reloading resource after create actions

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -574,7 +574,16 @@ class PanoptesObject(object):
             etag=self.etag
         )
         self.raw['id'] = response[self._api_slug][0]['id']
-        self.reload()
+        # set the etag from the response headers (POST 201 returns etag)
+        # PUT 200 doesn't return etag?
+        # TODO: check this etag is correctly set on an update response (API response?)
+        # maybe only do this for post responses else we'll clobber
+        # the GET etag for PUT update responses
+
+        # Note: there is no gaurantee that another client hasn't updated the resource
+        # between initial save / get response and this save
+        self.etag = response.headers.get('ETag')
+
         return response
 
     def reload(self):


### PR DESCRIPTION
closes #83 

On create actions, save the resource attributes and etag from the api response. On updates force a reload if the resource is used again.