### PR TITLE
Add buffer to bearer token expiration check

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -351,7 +351,8 @@ class Panoptes(object):
         return self.session.get(url, headers=headers).headers['x-csrf-token']
 
     def get_bearer_token(self):
-        if not self.bearer_token or self.bearer_expires < datetime.now():
+        check_time = datetime.now() - timedelta(minutes=1)
+        if not self.bearer_token or self.bearer_expires < check_time:
             grant_type = 'password'
 
             if self.client_secret:


### PR DESCRIPTION
Treat bearer token as expired if it is about to expire in the next minute.

I'm experiencing an edge case where the bearer token expires before firing a request, but after I call get_bearer_token in the python client. I'm working with caesar to PUT reductions made by SWAP from a classification stream. SWAP calls get_bearer_token every time a request is made to caesar, so the token refresh and expiration checking is handled by the python client. SWAP ran for at least 8 hours without issues, meaning that the token was being refreshed periodically by the python client.

The client refreshed the bearer token at 6:52:29, and a request made at 8:52:29 returned a 401 from caesar. The bearer token expired in the time it took to build and fire the request. I'm making requests externally from the python client, and only using the client to manage authorization tokens. This means that any error handling built into the python client's request functionality was not activated by the 401.

Adding a buffer to the expiration check would alleviate this issue. I set the delta to one minute on a suggestion from @camallen, but the duration is arbitrary.