### PR TITLE
Bearer token buffer

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -351,7 +351,7 @@ class Panoptes(object):
         return self.session.get(url, headers=headers).headers['x-csrf-token']
 
     def get_bearer_token(self):
-        check_time = datetime.now() - timedelta(minutes=1)
+        check_time = datetime.now() + timedelta(minutes=1)
         if not self.bearer_token or self.bearer_expires < check_time:
             grant_type = 'password'
 

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -351,8 +351,7 @@ class Panoptes(object):
         return self.session.get(url, headers=headers).headers['x-csrf-token']
 
     def get_bearer_token(self):
-        check_time = datetime.now() + timedelta(minutes=1)
-        if not self.bearer_token or self.bearer_expires < check_time:
+        if not self.bearer_token or self.bearer_expired():
             grant_type = 'password'
 
             if self.client_secret:
@@ -399,6 +398,25 @@ class Panoptes(object):
                 + timedelta(seconds=token_response['expires_in'])
             )
         return self.bearer_token
+
+    def bearer_expired(self):
+        """
+        Check if the stored bearer token has expired
+        """
+        # Pretend expired if there is no token
+        if self.bearer_token is None:
+            return True
+
+        now = datetime.now()
+        expires = self.bearer_expires
+        # Buffer to allow time for requests
+        # to fire without expiring in transit
+        buffer_ = timedelta(minutes=2)
+
+        # Add time to now --> pretend time is later
+        # Effect of making token expire earlier
+        return expires < now + buffer_
+
 
 class PanoptesObject(object):
     RESERVED_ATTRIBUTES = (

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -351,7 +351,7 @@ class Panoptes(object):
         return self.session.get(url, headers=headers).headers['x-csrf-token']
 
     def get_bearer_token(self):
-        if not self.bearer_token or self.bearer_expired():
+        if not self.valid_bearer_token():
             grant_type = 'password'
 
             if self.client_secret:
@@ -399,13 +399,13 @@ class Panoptes(object):
             )
         return self.bearer_token
 
-    def bearer_expired(self):
+    def valid_bearer_token(self):
         """
         Check if the stored bearer token has expired
         """
-        # Pretend expired if there is no token
-        if self.bearer_token is None:
-            return True
+        # Return invalid if there is no token
+        if not self.has_bearer_token():
+            return False
 
         now = datetime.now()
         expires = self.bearer_expires
@@ -415,7 +415,13 @@ class Panoptes(object):
 
         # Add time to now --> pretend time is later
         # Effect of making token expire earlier
-        return expires < now + buffer_
+        return now + buffer_ <= expires
+
+    def has_bearer_token(self):
+        """
+        Check if the client has a bearer token
+        """
+        return self.bearer_token is not None
 
 
 class PanoptesObject(object):

--- a/panoptes_client/tests/test_bearer_expiry.py
+++ b/panoptes_client/tests/test_bearer_expiry.py
@@ -1,0 +1,88 @@
+
+from panoptes_client.panoptes import Panoptes
+
+import datetime
+import unittest
+from unittest.mock import patch
+
+
+class MockDate(datetime.datetime):
+
+    _fake = None
+
+    @classmethod
+    def fake(cls, time):
+        cls._fake = time
+
+    @classmethod
+    def now(cls, tz=None):
+        return cls._fake
+
+
+@patch('panoptes_client.panoptes.datetime', MockDate)
+class TestBearer(unittest.TestCase):
+
+    def test_early(self):
+        target = datetime.datetime(2017, 1, 1, 10, 0, 0)
+        MockDate.fake(target)
+
+        print(datetime.datetime.now())
+
+        client = Panoptes()
+        client.bearer_token = True
+
+        client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
+
+        assert client.bearer_expired() is False
+
+    def test_early_2(self):
+        target = datetime.datetime(2017, 1, 1, 11, 58, 0)
+        MockDate.fake(target)
+
+        print(datetime.datetime.now())
+
+        client = Panoptes()
+        client.bearer_token = True
+
+        client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
+
+        assert client.bearer_expired() is False
+
+    def test_late(self):
+        target = datetime.datetime(2017, 1, 1, 14, 0, 0)
+        MockDate.fake(target)
+
+        print(datetime.datetime.now())
+
+        client = Panoptes()
+        client.bearer_token = True
+
+        client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
+
+        assert client.bearer_expired() is True
+
+    def test_late_2(self):
+        target = datetime.datetime(2017, 1, 1, 12, 0, 1)
+        MockDate.fake(target)
+
+        print(datetime.datetime.now())
+
+        client = Panoptes()
+        client.bearer_token = True
+
+        client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
+
+        assert client.bearer_expired() is True
+
+    def test_in_buffer(self):
+        target = datetime.datetime(2017, 1, 1, 11, 59, 0)
+        MockDate.fake(target)
+
+        print(datetime.datetime.now())
+
+        client = Panoptes()
+        client.bearer_token = True
+
+        client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
+
+        assert client.bearer_expired() is True

--- a/panoptes_client/tests/test_bearer_expiry.py
+++ b/panoptes_client/tests/test_bearer_expiry.py
@@ -3,7 +3,12 @@ from panoptes_client.panoptes import Panoptes
 
 import datetime
 import unittest
-from mock import patch
+import sys
+
+if sys.version_info <= (3, 0):
+    from mock import patch
+else:
+    from unittest.mock import patch
 
 
 class MockDate(datetime.datetime):
@@ -26,63 +31,64 @@ class TestBearer(unittest.TestCase):
         target = datetime.datetime(2017, 1, 1, 10, 0, 0)
         MockDate.fake(target)
 
-        print(datetime.datetime.now())
-
         client = Panoptes()
         client.bearer_token = True
 
         client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
 
-        assert client.bearer_expired() is False
+        assert client.valid_bearer_token() is True
 
     def test_early_2(self):
         target = datetime.datetime(2017, 1, 1, 11, 58, 0)
         MockDate.fake(target)
 
-        print(datetime.datetime.now())
-
         client = Panoptes()
         client.bearer_token = True
 
         client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
 
-        assert client.bearer_expired() is False
+        assert client.valid_bearer_token() is True
 
     def test_late(self):
         target = datetime.datetime(2017, 1, 1, 14, 0, 0)
         MockDate.fake(target)
 
-        print(datetime.datetime.now())
-
         client = Panoptes()
         client.bearer_token = True
 
         client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
 
-        assert client.bearer_expired() is True
+        assert client.valid_bearer_token() is False
 
     def test_late_2(self):
         target = datetime.datetime(2017, 1, 1, 12, 0, 1)
         MockDate.fake(target)
 
-        print(datetime.datetime.now())
-
         client = Panoptes()
         client.bearer_token = True
 
         client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
 
-        assert client.bearer_expired() is True
+        assert client.valid_bearer_token() is False
 
     def test_in_buffer(self):
         target = datetime.datetime(2017, 1, 1, 11, 59, 0)
         MockDate.fake(target)
 
-        print(datetime.datetime.now())
-
         client = Panoptes()
         client.bearer_token = True
 
         client.bearer_expires = datetime.datetime(2017, 1, 1, 12, 0, 0)
 
-        assert client.bearer_expired() is True
+        assert client.valid_bearer_token() is False
+
+    def test_has_token(self):
+        client = Panoptes()
+        client.bearer_token = True
+
+        assert client.has_bearer_token() is True
+
+    def test_has_no_token(self):
+        client = Panoptes()
+
+        assert client.has_bearer_token() is False

--- a/panoptes_client/tests/test_bearer_expiry.py
+++ b/panoptes_client/tests/test_bearer_expiry.py
@@ -3,7 +3,7 @@ from panoptes_client.panoptes import Panoptes
 
 import datetime
 import unittest
-from unittest.mock import patch
+from mock import patch
 
 
 class MockDate(datetime.datetime):

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,6 @@ setup(
         'requests>=2.4.2',
         'future',
         'python-magic',
+        'mock',
     ],
 )


### PR DESCRIPTION
The bearer token buffer in the last pull request subtracted the buffer from the clock, meaning the token would appear to expire AFTER it actually expired. 

This pull request makes the bearer expiration check an independent testable function. It also fixes the buffer direction by adding time to the clock, making it appear that the clock is later and expiring the token early.

Sorry about the bad code earlier, I should have tested it better.