### PR TITLE
update readme to add the batch_size keyword for batch upload of subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ subject.metadata['image_title'] = 'My image'
 subject.save()
 
 # SubjectSet.add() can take a list of Subjects
-subject_set.add([subject1, subject2, subject3])
+subjects_list=[subject1, subject2, subject3]
+subject_set.add(subjects_list,batch_size=len(subjects_list))
 # or just one at a time (but this is slower than doing several together)
 subject_set.add(subject1)
 subject_set.add(subject2)


### PR DESCRIPTION
I needed to add the batch_size keyword to explicitly give the length of the list I added. Cam had mentioned this was faster.  I didn't see this example in the readme so I updated the one example ofa batch upload