### PR TITLE
Editable collection project link

### DIFF
--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -92,3 +92,29 @@ class Collection(PanoptesObject):
             _subjects.append(_subject_id)
 
         return _subjects
+
+    def add_default_subject(self, subject):
+        if not (
+            isinstance(subject, Subject)
+            or isinstance(subject, (int, str,))
+        ):
+            raise TypeError
+
+        _subject_id = subject.id if isinstance(subject, Subject) else str(subject)
+
+        self.http_post(
+            '{}/links/default_subject/{}'.format(self.id, _subject_id)
+        )
+
+    def link_to_project(self, project):
+        if not (
+            isinstance(project, Project)
+            or isinstance(project, (int, str))
+        ):
+            raise TypeError
+
+        _project_id = project.id if isinstance(project, Project) else str(project)
+
+        self.http_post(
+            '{}/links/project/{}'.format(self.id, _project_id)
+        )

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -16,6 +16,7 @@ class Collection(PanoptesObject):
         {
             'links': (
                 'project',
+                'default_subject',
             ),
         },
     )

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -12,7 +12,12 @@ class Collection(PanoptesObject):
     _edit_attributes = (
         'name',
         'display_name',
-        'private'
+        'private',
+        {
+            'links': (
+                'project',
+            ),
+        },
     )
 
     @property

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -3,6 +3,7 @@ from builtins import str
 
 from panoptes_client.panoptes import PanoptesObject
 from panoptes_client.subject import Subject
+from panoptes_client.project import Project
 from panoptes_client.utils import batchable
 
 
@@ -99,8 +100,10 @@ class Collection(PanoptesObject):
             or isinstance(subject, (int, str,))
         ):
             raise TypeError
-
-        _subject_id = subject.id if isinstance(subject, Subject) else str(subject)
+        if isinstance(subject, Subject):
+            _subject_id = subject.id
+        else:
+            _subject_id = str(subject)
 
         self.http_post(
             '{}/links/default_subject/{}'.format(self.id, _subject_id)
@@ -113,7 +116,10 @@ class Collection(PanoptesObject):
         ):
             raise TypeError
 
-        _project_id = project.id if isinstance(project, Project) else str(project)
+        if isinstance(project, Project):
+            _project_id = project.id
+        else:
+            _project_id = str(project)
 
         self.http_post(
             '{}/links/project/{}'.format(self.id, _project_id)

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -88,9 +88,9 @@ class Collection(PanoptesObject):
 
         return _subjects
 
-    def add_default_subject(self, subject):
+    def set_default_subject(self, subject):
         """
-        Adds the subject's location media URL as a link.
+        Sets the subject's location media URL as a link.
         It displays as the default subject on PFE.
 
         - **subject** can be a single :py:class:`.Subject` instance or a single
@@ -98,8 +98,8 @@ class Collection(PanoptesObject):
 
         Examples::
 
-            collection.add_default_subject(1234)
-            collection.add_default_subject(Subject(1234))
+            collection.set_default_subject(1234)
+            collection.set_default_subject(Subject(1234))
         """
         if not (
             isinstance(subject, Subject)
@@ -140,6 +140,6 @@ class Collection(PanoptesObject):
             _project_id = str(project)
 
         self.http_post(
-            '{}/links/project'.format(self.id),
+            '{}/links/projects'.format(self.id),
             json={'project': _project_id},
         )

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -90,7 +90,8 @@ class Collection(PanoptesObject):
 
     def add_default_subject(self, subject):
         """
-        Adds the subject's location media URL as a link. It displays as the default subject on PFE.
+        Adds the subject's location media URL as a link.
+        It displays as the default subject on PFE.
 
         - **subject** can be a single :py:class:`.Subject` instance or a single
           subject ID.

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -14,12 +14,6 @@ class Collection(PanoptesObject):
         'name',
         'display_name',
         'private',
-        {
-            'links': (
-                'project',
-                'default_subject',
-            ),
-        },
     )
 
     @property
@@ -95,6 +89,17 @@ class Collection(PanoptesObject):
         return _subjects
 
     def add_default_subject(self, subject):
+        """
+        Adds the subject's location media URL as a link. It displays as the default subject on PFE.
+
+        - **subject** can be a single :py:class:`.Subject` instance or a single
+          subject ID.
+
+        Examples::
+
+            collection.add_default_subject(1234)
+            collection.add_default_subject(Subject(1234))
+        """
         if not (
             isinstance(subject, Subject)
             or isinstance(subject, (int, str,))
@@ -106,10 +111,22 @@ class Collection(PanoptesObject):
             _subject_id = str(subject)
 
         self.http_post(
-            '{}/links/default_subject/{}'.format(self.id, _subject_id)
+            '{}/links/default_subject'.format(self.id),
+            json={'default_subject': _subject_id},
         )
 
     def link_to_project(self, project):
+        """
+        Links the collection to a project.
+
+        - **project** can be a single :py:class:`.Project` instance or a single
+          project ID.
+
+        Examples::
+
+            collection.link_to_project(5678)
+            collection.link_to_project(Project(5678))
+        """
         if not (
             isinstance(project, Project)
             or isinstance(project, (int, str))
@@ -122,5 +139,6 @@ class Collection(PanoptesObject):
             _project_id = str(project)
 
         self.http_post(
-            '{}/links/project/{}'.format(self.id, _project_id)
+            '{}/links/project'.format(self.id),
+            json={'project': _project_id},
         )

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -14,6 +14,11 @@ class Collection(PanoptesObject):
         'name',
         'display_name',
         'private',
+        {
+            'links': (
+                'project',
+            ),
+        },
     )
 
     @property
@@ -114,32 +119,4 @@ class Collection(PanoptesObject):
         self.http_post(
             '{}/links/default_subject'.format(self.id),
             json={'default_subject': _subject_id},
-        )
-
-    def link_to_project(self, project):
-        """
-        Links the collection to a project.
-
-        - **project** can be a single :py:class:`.Project` instance or a single
-          project ID.
-
-        Examples::
-
-            collection.link_to_project(5678)
-            collection.link_to_project(Project(5678))
-        """
-        if not (
-            isinstance(project, Project)
-            or isinstance(project, (int, str))
-        ):
-            raise TypeError
-
-        if isinstance(project, Project):
-            _project_id = project.id
-        else:
-            _project_id = str(project)
-
-        self.http_post(
-            '{}/links/projects'.format(self.id),
-            json={'project': _project_id},
         )

--- a/panoptes_client/collection.py
+++ b/panoptes_client/collection.py
@@ -3,7 +3,6 @@ from builtins import str
 
 from panoptes_client.panoptes import PanoptesObject
 from panoptes_client.subject import Subject
-from panoptes_client.project import Project
 from panoptes_client.utils import batchable
 
 


### PR DESCRIPTION
Gravity Spy needs to be able to programmatically create collections, so being able to edit the project and default_subject links are required. 