### PR TITLE
Interactive login

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -105,7 +105,7 @@ class Panoptes(object):
         )
         self.username = None
         self.password = None
-        self._auth(username, password, login)
+        self._auth(login, username, password)
 
         self.redirect_url = \
             redirect_url or os.environ.get('PANOPTES_REDIRECT_URL')

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -4,6 +4,7 @@ from builtins import str
 import logging
 import os
 import requests
+import getpass
 
 from datetime import datetime, timedelta
 
@@ -394,6 +395,11 @@ class Panoptes(object):
             )
         self.logged_in = True
         return response
+
+    def interactive_login(self):
+        user = input('Username: ')
+        password = getpass.getpass()
+        self.login(user, password)
 
     def get_csrf_token(self):
         url = self.endpoint + '/users/sign_in'

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -94,6 +94,7 @@ class Panoptes(object):
         redirect_url=None,
         username=None,
         password=None,
+        login=None,
         admin=False
     ):
         Panoptes._client = self
@@ -102,8 +103,10 @@ class Panoptes(object):
             'PANOPTES_ENDPOINT',
             'https://www.zooniverse.org'
         )
-        self.username = username or os.environ.get('PANOPTES_USERNAME')
-        self.password = password or os.environ.get('PANOPTES_PASSWORD')
+        self.username = None
+        self.password = None
+        self._auth(username, password, login)
+
         self.redirect_url = \
             redirect_url or os.environ.get('PANOPTES_REDIRECT_URL')
         self.client_secret = \
@@ -359,6 +362,23 @@ class Panoptes(object):
             endpoint=endpoint
         )
 
+    def _auth(self, auth_type, username, password):
+        if username is None or password is None:
+            if auth_type == 'interactive':
+                username, password = self.interactive_login()
+
+            elif auth_type == 'keyring':
+                # Get credentials from python keyring
+                pass
+
+            else:
+                username = os.environ.get('PANOPTES_USERNAME')
+                password = os.environ.get('PANOPTES_PASSWORD')
+
+        self.username = username
+        self.password = password
+
+
     def login(self, username=None, password=None):
         if not username:
             username = self.username
@@ -397,9 +417,10 @@ class Panoptes(object):
         return response
 
     def interactive_login(self):
-        user = input('Username: ')
+        username = input('Username: ')
         password = getpass.getpass()
-        self.login(user, password)
+
+        return username, password
 
     def get_csrf_token(self):
         url = self.endpoint + '/users/sign_in'


### PR DESCRIPTION
Using current functionality, logging in requires a user to manually
enter their credentials within their script (using the login() function or
by passing credentials to the Panoptes object initializer), or to store them as
environment variables in `PANOPTES_USERNAME` and `PANOPTES_PASSWORD`.

This commit adds functionality for an interactive login. This would allow a
user to enter their credentials manually when running a script that doesn't
involve storing the credentials in a static file or in an environment
variable.