### PR TITLE
switch to distinct oauth apps for the python client

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -61,10 +61,10 @@ class Panoptes(object):
 
     _endpoint_client_ids = {
         'default': (
-            'f79cf5ea821bb161d8cbb52d061ab9a2321d7cb169007003af66b43f7b79ce2a'
+            'ce310d45f951de68c4cc8ef46ca38cc0a008f607a2026680295757bfef99f43c'
         ),
         'https://panoptes-staging.zooniverse.org': (
-            '535759b966935c297be11913acee7a9ca17c025f9f15520e7504728e71110a27'
+            'e094b63362fdef0548e0bbcc6e6cb5996c422d3a770074ef972432d57d41049c'
         ),
     }
 


### PR DESCRIPTION
Ensure we have distinct applications for the different clients, PFE, python, etc. I've setup the new applications to have the correct rights and can be located at:
+ https://panoptes-staging.zooniverse.org/oauth/applications/44
+ https://panoptes.zooniverse.org/oauth/applications/97

Prompted by https://github.com/zooniverse/Panoptes/pull/2847 - this will require me to audit and change each app's confidential attribute according to how it's being used.