### PR TITLE
Retry creating subjects on failure

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -64,6 +64,7 @@ class Subject(PanoptesObject):
             attempts=UPLOAD_RETRY_LIMIT,
             sleeptime=RETRY_BACKOFF_INTERVAL,
             retry_exceptions=(PanoptesAPIException,),
+            log_args=False,
         )
 
         if not response:
@@ -83,6 +84,7 @@ class Subject(PanoptesObject):
                     attempts=UPLOAD_RETRY_LIMIT,
                     sleeptime=RETRY_BACKOFF_INTERVAL,
                     retry_exceptions=(requests.exceptions.RequestException,),
+                    log_args=False,
                 )
 
     def _upload_media(self, url, media_data, media_type):

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -98,8 +98,10 @@ class Subject(PanoptesObject):
 
     def set_raw(self, raw, etag=None, loaded=True):
         super(Subject, self).set_raw(raw, etag, loaded)
-        if loaded:
+        if loaded and self.metadata:
             self._original_metadata = dict(self.metadata)
+        elif loaded:
+            self._original_metadata = None
 
     def add_location(self, location):
         """

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         'requests>=2.4.2,<2.20',
         'future>=0.16,<0.17',
         'python-magic>=0.4,<0.5',
+        'redo>=1.6,<1.7',
     ],
     extras_require={
         'testing': [

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'requests>=2.4.2,<2.20',
         'future>=0.16,<0.17',
         'python-magic>=0.4,<0.5',
-        'redo>=1.6,<1.7',
+        'redo>=1.7',
     ],
     extras_require={
         'testing': [


### PR DESCRIPTION
Using the redo module. Also use this module for retrying media uploads.

Also fixes a TypeError introduced in 1.0.2.

This will need to wait for mozilla-releng/redo#43 to be fixed, because otherwise
subject uploads will flood the terminal with logging messages.