### PR TITLE
Fix: Can't save new objects with individual links

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -935,7 +935,7 @@ class LinkResolver(object):
 
     def __setattr__(self, name, value):
         reserved_names = ('raw', 'parent')
-        if name not in reserved_names and name in self.parent.raw['links']:
+        if name not in reserved_names and name not in dir(self):
             if not self.parent._loaded:
                 self.parent.reload()
             if isinstance(value, PanoptesObject):

--- a/panoptes_client/tests/test_linkresolver.py
+++ b/panoptes_client/tests/test_linkresolver.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+import sys
+
+if sys.version_info <= (3, 0):
+    from mock import Mock
+else:
+    from unittest.mock import Mock
+
+from panoptes_client.panoptes import LinkResolver
+
+
+class TestLinkResolver(unittest.TestCase):
+    def test_set_new_link(self):
+        parent = Mock()
+        parent.raw = {'links': {}}
+
+        target = Mock()
+
+        resolver = LinkResolver(parent)
+        resolver.newlink = target
+        self.assertEqual(parent.raw['links'].get('newlink', None), target)

--- a/panoptes_client/tests/test_subject_set.py
+++ b/panoptes_client/tests/test_subject_set.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+import sys
+
+if sys.version_info <= (3, 0):
+    from mock import patch, Mock
+else:
+    from unittest.mock import patch, Mock
+
+from panoptes_client.subject_set import SubjectSet
+
+
+class TestSubjectSet(unittest.TestCase):
+    def test_create(self):
+        with patch('panoptes_client.panoptes.Panoptes') as pc:
+            pc.client().post = Mock(return_value=(
+                {
+                    'subject_sets': [{
+                        'id': 0,
+                        'display_name': '',
+                    }],
+                },
+                '',
+            ))
+            subject_set = SubjectSet()
+            subject_set.links.project = 1234
+            subject_set.display_name = 'Name'
+            subject_set.save()
+
+            pc.client().post.assert_called_with(
+                '/subject_sets',
+                json={
+                    'subject_sets': {
+                        'display_name': 'Name',
+                        'links': {
+                            'project': 1234,
+                        }
+                    }
+                },
+                etag=None,
+            )


### PR DESCRIPTION
Fixes #205

If the link slug wasn't already in the list of links, trying to set the
link would set an attribute on the `PanoptesObject` instead of creating an
entry in `raw['links']`.

This PR changes the setattr logic to make sure the slug _isn't_ an
attribute rather than checking it _is_ a link. This allows setting links
that the client doesn't already know about, but has the side effect of
allowing invalid links. This is actually a good thing, because invalid
links will be rejected by the API, whereas before they would have been
set as attributes and silently discarded on save.