### PR TITLE
add install for libmagic

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+RUN apk --no-cache add libmagic
+
 WORKDIR /usr/src/panoptes-python-client
 
 COPY setup.py .

--- a/Dockerfile.dev2
+++ b/Dockerfile.dev2
@@ -1,5 +1,7 @@
 FROM python:2.7-alpine
 
+RUN apk --no-cache add libmagic
+
 WORKDIR /usr/src/panoptes-python-client
 
 COPY setup.py .

--- a/Dockerfile.stable
+++ b/Dockerfile.stable
@@ -1,3 +1,5 @@
 FROM python:3-alpine
 
+RUN apk --no-cache add libmagic
+
 RUN pip install panoptes-client

--- a/Dockerfile.stable2
+++ b/Dockerfile.stable2
@@ -1,3 +1,5 @@
 FROM python:2.7-alpine
 
+RUN apk --no-cache add libmagic
+
 RUN pip install panoptes-client


### PR DESCRIPTION
ensure the client can use python libmagic - ideally these would be pushed to dockerhub as offical images for reuse via jenkins file on master changes / releases

without the changes
```
>>> from panoptes_client import Panoptes, Project
Broken libmagic installation detected. The python-magic module is installed but can't be imported. Please check that both python-magic and the libmagic shared library are installed correctly. Uploading media other than images may not work.
```

with changes
```
>>> from panoptes_client import Panoptes, Project
>>> quit()
```