### PR TITLE
Deep copy of initial workflow config

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -13,6 +13,7 @@ import requests
 import threading
 import time
 
+from copy import deepcopy
 from concurrent.futures import ThreadPoolExecutor
 
 try:
@@ -208,7 +209,7 @@ class Subject(PanoptesObject):
     def set_raw(self, raw, etag=None, loaded=True):
         super(Subject, self).set_raw(raw, etag, loaded)
         if loaded and self.metadata:
-            self._original_metadata = dict(self.metadata)
+            self._original_metadata = copy.deepcopy(self.metadata)
         elif loaded:
             self._original_metadata = None
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -209,7 +209,7 @@ class Subject(PanoptesObject):
     def set_raw(self, raw, etag=None, loaded=True):
         super(Subject, self).set_raw(raw, etag, loaded)
         if loaded and self.metadata:
-            self._original_metadata = copy.deepcopy(self.metadata)
+            self._original_metadata = deepcopy(self.metadata)
         elif loaded:
             self._original_metadata = None
 

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from builtins import str
+from copy import deepcopy
 
 from panoptes_client.exportable import Exportable
 from panoptes_client.panoptes import PanoptesObject, LinkResolver
@@ -36,7 +37,7 @@ class Workflow(PanoptesObject, Exportable):
     def set_raw(self, raw, etag=None, loaded=True):
         super(Workflow, self).set_raw(raw, etag, loaded)
         if loaded and self.configuration:
-            self._original_configuration = dict(self.configuration)
+            self._original_configuration = deepcopy(self.configuration)
         elif loaded:
             self._original_configuration = None
 


### PR DESCRIPTION
Determining whether to save the workflow configuration relies on comparison between a potentially updated configuration dict and a copy of the original taken when the Workflow instance was created. Using assignment or even copy construction can (apparently not always) result in the "copy" in fact being a reference to the object which may be modified. This means that the two always compare equal and the config is never saved. Using copy.deepcopy solves this issue.