### PR TITLE
Updated pip GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or for development or testing, you can install the development version directly
 from GitHub:
 
 ```
-$ pip install -U git+git://github.com/zooniverse/panoptes-python-client.git
+$ pip install -U git+https://github.com/zooniverse/panoptes-python-client.git
 ```
 
 Upgrade an existing installation:


### PR DESCRIPTION
Suggested modification to README. The "git+git" URL form does not work unless SSH keys have been configured. The "git+https" form is more likely to work.