### PR TITLE
Add attached image methods to Project

### DIFF
--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -151,5 +151,27 @@ class Project(PanoptesObject, Exportable):
         """
         return self.http_get('{}/avatar'.format(self.id))[0]
 
+    @property
+    def attached_images(self):
+        return self.http_get('{}/attached_images'.format(self.id))[0]
+
+    def add_attached_image(
+        self,
+        src,
+        content_type='image/png',
+        external_link=True,
+        metadata={},
+    ):
+        return self.http_post(
+            '{}/attached_images'.format(self.id),
+            json={'media': {
+                'src': src,
+                'content_type': content_type,
+                'external_link': external_link,
+                'metadata': metadata,
+            }},
+        )
+
+
 LinkResolver.register(Project)
 LinkResolver.register(Project, 'projects')


### PR DESCRIPTION
Waiting for the corresponding API update to be deployed before I can test `add_attached_image`.

I really wanted to add a reusable `AttachedImage` class, so attached images could be accessed/managed as normal linked objects, but the lack of a route to access them without the parent object's ID makes that difficult because of assumptions made in `PanoptesObject` (i.e. we'd need a route like `/api/attached_images/:attached_image_id` – maybe something to consider for the future).