### PR TITLE
Fix media uploads for existing subjects

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -104,9 +104,7 @@ class Subject(PanoptesObject):
         if not self.metadata:
             self.metadata = {}
             self._original_metadata = {}
-        self._media_files = []
-        for _l in self.locations:
-            self._media_files.append(None)
+        self._media_files = [None] * len(self.locations)
 
     def save(self, client=None):
         """

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -175,6 +175,9 @@ class Subject(PanoptesObject):
                             ),
                             log_args=False,
                         )
+
+                self._media_files = [None] * len(self.locations)
+                
             finally:
                 if not async_save:
                     upload_exec.shutdown()

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -105,6 +105,8 @@ class Subject(PanoptesObject):
             self.metadata = {}
             self._original_metadata = {}
         self._media_files = []
+        for l in self.locations:
+            self._media_files.append(None)
 
     def save(self, client=None):
         """
@@ -242,6 +244,7 @@ class Subject(PanoptesObject):
         if type(location) is dict:
             self.locations.append(location)
             self._media_files.append(None)
+            self.modified_attributes.add('locations')
             return
         elif type(location) in (str,) + _OLD_STR_TYPES:
             f = open(location, 'rb')
@@ -264,6 +267,7 @@ class Subject(PanoptesObject):
                 media_type = 'image/{}'.format(media_type)
             self.locations.append(media_type)
             self._media_files.append(media_data)
+            self.modified_attributes.add('locations')
         finally:
             f.close()
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -105,7 +105,7 @@ class Subject(PanoptesObject):
             self.metadata = {}
             self._original_metadata = {}
         self._media_files = []
-        for l in self.locations:
+        for _l in self.locations:
             self._media_files.append(None)
 
     def save(self, client=None):

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -177,7 +177,7 @@ class Subject(PanoptesObject):
                         )
 
                 self._media_files = [None] * len(self.locations)
-                
+
             finally:
                 if not async_save:
                     upload_exec.shutdown()


### PR DESCRIPTION
Closes #239

Initialize existing `Subject()` instances with a `_media_files` array whose length matches that of `locations` array and is filled with `None` elements. Also, add `locations` to `modified_attributes` when `add_location` is called. These two edits fixes issue where `add_location()` calls for existing subjects -- those that already have been saved with existing media `locations` -- was failing.