### PR TITLE
Add Azure header to all PUT requests

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -58,7 +58,6 @@ class Panoptes(object):
         'GET': {},
         'PUT': {
             'Content-Type': 'application/json',
-            'x-ms-blob-type': 'BlockBlob',
         },
         'POST': {
             'Content-Type': 'application/json',

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -58,6 +58,7 @@ class Panoptes(object):
         'GET': {},
         'PUT': {
             'Content-Type': 'application/json',
+            'x-ms-blob-type': 'BlockBlob',
         },
         'POST': {
             'Content-Type': 'application/json',

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -183,6 +183,7 @@ class Subject(PanoptesObject):
             url,
             headers={
                 'Content-Type': media_type,
+                'x-ms-blob-type': 'BlockBlob',
             },
             data=media_data,
         )


### PR DESCRIPTION
The header can exist for all PUT requests, as everything but Azure will ignore it. It's required to properly upload files/blobs to Azure Storage via a SAS-signed request