### PR TITLE
Prepare 1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0 (2020-09-27)
+- Change: Add Azure header to PUT requests
+
 ## 1.2 (2020-06-13)
 
 - New: Add `SubjectWorkflowStatus` class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 1.3.0 (2020-09-27)
-- Change: Add Azure header to PUT requests
+- Change: Allow uploads to Azure cloud, add header to cloud upload PUT requests
 
 ## 1.2 (2020-06-13)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     url='https://github.com/zooniverse/panoptes-python-client',
     author='Adam McMaster',
     author_email='adam@zooniverse.org',
-    version='1.2.0',
+    version='1.3.0',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Includes the Azure header on PUT requests for when the migration of data and infrastructure is finished on the API side.