### PR TITLE
Document login="interactive" and "keyring" connect() kwargs

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -93,6 +93,9 @@ class Panoptes(object):
 
         - **username** is your Zooniverse.org username.
         - **password** is your Zooniverse.org password.
+        - **login** == "interactive" will prompt for the Zooniverse.org
+          username and password, while "keyring" will get the login
+          credentials from the python keyring.
         - **endpoint** is the HTTP API endpoint you'd like to connect to.
           Defaults to **https://www.zooniverse.org**. Should not include a
           trailing slash.


### PR DESCRIPTION
I found the PR #140 that added the interactive login kwarg to `connect()`, but without finding that PR, I wouldn't have known about it. I added a docstring for the `login` kwarg to `connect()` here, but I think it would be good to document the various login methods in the user's guide as well. As it is, the only approach to establishing the connection that I can find in the docs involves writing your username and password directly in the script, which is very bad for security. But I'm not sure where in the `user_guide.rst` such a discussion should go, nor do i know of all the possibilities.