### PR TITLE
Add support for all dict-type editable attributes (v2)

### DIFF
--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -36,6 +36,7 @@ class Project(PanoptesObject, Exportable):
         'introduction',
         'private',
         'primary_language',
+        'configuration',
     )
     _link_collection = ProjectLinkCollection
 

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from copy import deepcopy
 
 from panoptes_client.panoptes import (
     LinkCollection,
@@ -39,6 +40,29 @@ class Project(PanoptesObject, Exportable):
         'configuration',
     )
     _link_collection = ProjectLinkCollection
+
+    def __init__(self, raw={}, etag=None):
+        super(Project, self).__init__(raw, etag)
+        if not self.configuration:
+            self.configuration = {}
+            self._original_configuration = {}
+
+    def set_raw(self, raw, etag=None, loaded=True):
+        super(Project, self).set_raw(raw, etag, loaded)
+        if loaded and self.configuration:
+            self._original_configuration = deepcopy(self.configuration)
+        elif loaded:
+            self._original_configuration = None
+
+    def save(self):
+        """
+        Adds project configuration to the list of savable attributes
+        if it has changed.
+        """
+        if not self.configuration == self._original_configuration:
+            self.modified_attributes.add('configuration')
+
+        super(Project, self).save()
 
     @classmethod
     def find(cls, id='', slug=None):

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -56,8 +56,8 @@ class Workflow(PanoptesObject, Exportable):
 
     def save(self):
         """
-        Adds workflow configuration to the list of savable attributes
-        if it has changed.
+        Adds workflow configuration, retirement, and tasks dicts to the list of
+        savable attributes if it has changed.
         """
         if not self.configuration == self._original_configuration:
             self.modified_attributes.add('configuration')

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -33,13 +33,26 @@ class Workflow(PanoptesObject, Exportable):
         if not self.configuration:
             self.configuration = {}
             self._original_configuration = {}
+        if not self.retirement:
+            self.retirement = {}
+            self._original_retirement = {}
+        if not self.tasks:
+            self.tasks = {}
+            self._original_tasks = {}
 
     def set_raw(self, raw, etag=None, loaded=True):
         super(Workflow, self).set_raw(raw, etag, loaded)
-        if loaded and self.configuration:
-            self._original_configuration = deepcopy(self.configuration)
+        if loaded:
+            if self.configuration:
+                self._original_configuration = deepcopy(self.configuration)
+            if self.retirement:
+                self._original_retirement = deepcopy(self.retirement)
+            if self.tasks:
+                self._original_tasks = deepcopy(self.tasks)
         elif loaded:
             self._original_configuration = None
+            self._original_retirement = None
+            self._original_tasks = None
 
     def save(self):
         """
@@ -48,6 +61,10 @@ class Workflow(PanoptesObject, Exportable):
         """
         if not self.configuration == self._original_configuration:
             self.modified_attributes.add('configuration')
+        if not self.retirement == self._original_retirement:
+            self.modified_attributes.add('retirement')
+        if not self.tasks == self._original_tasks:
+            self.modified_attributes.add('tasks')
 
         super(Workflow, self).save()
 


### PR DESCRIPTION
Rebased version of #236, but same goal: building directly from #222, expand editable dicts in workflow.py and project.py to include `Project.configuration`, `Workflow.retirement`, and `Workflow.tasks`.

