### PR TITLE
Subjectworkflowstatus helpers

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 
 _OLD_STR_TYPES = (str,)
 try:
@@ -213,6 +214,9 @@ class Subject(PanoptesObject):
             self._original_metadata = deepcopy(self.metadata)
         elif loaded:
             self._original_metadata = None
+    
+    def status_in_workflow(self, workflow_id):
+        return list(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
 
     def add_location(self, location):
         """

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -216,6 +216,13 @@ class Subject(PanoptesObject):
             self._original_metadata = None
 
     def status_in_workflow(self, workflow_id):
+        """
+        Returns SubjectWorkflowStatus of Subject in Workflow
+
+        Example::
+
+            subject.status_in_workflow(4321)
+        """
         return next(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
 
     def add_location(self, location):

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -215,13 +215,13 @@ class Subject(PanoptesObject):
         elif loaded:
             self._original_metadata = None
 
-    def status_in_workflow(self, workflow_id):
+    def subject_workflow_status(self, workflow_id):
         """
         Returns SubjectWorkflowStatus of Subject in Workflow
 
         Example::
 
-            subject.status_in_workflow(4321)
+            subject.subject_workflow_status(4321)
         """
         return next(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -214,7 +214,7 @@ class Subject(PanoptesObject):
             self._original_metadata = deepcopy(self.metadata)
         elif loaded:
             self._original_metadata = None
-    
+
     def status_in_workflow(self, workflow_id):
         return list(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -216,7 +216,7 @@ class Subject(PanoptesObject):
             self._original_metadata = None
 
     def status_in_workflow(self, workflow_id):
-        return list(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
+        return next(SubjectWorkflowStatus.where(subject_id=self.id, workflow_id=workflow_id))
 
     def add_location(self, location):
         """

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -160,7 +160,7 @@ class Workflow(PanoptesObject, Exportable):
             workflow.subject_workflow_status(1234)
         """
         return next(SubjectWorkflowStatus.where(subject_id=subject_id, workflow_id=self.id))
-    
+
     def subject_workflow_statuses(self, subject_set_id):
         """
         A generator which yields :py:class:`.SubjectWorkflowStatus` objects for subjects in the

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -118,9 +118,9 @@ class Workflow(PanoptesObject, Exportable):
 
     def subject_status(self, subject_id):
         """
-        Returns an list of SubjectWorkflowStatuses of the current workflow given subject_id
+        Returns an SubjectWorkflowStatuses of the current workflow given subject_id
         """
-        return list(SubjectWorkflowStatus.where(subject_id=subject_id, workflow_id=self.id))
+        return next(SubjectWorkflowStatus.where(subject_id=subject_id, workflow_id=self.id))
 
     @property
     def versions(self):

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -115,7 +115,7 @@ class Workflow(PanoptesObject, Exportable):
         """
 
         return self.links.subject_sets.remove(subject_sets)
-    
+
     def subject_status(self, subject_id):
         """
         Returns an list of SubjectWorkflowStatuses of the current workflow given subject_id

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -117,7 +117,10 @@ class Workflow(PanoptesObject, Exportable):
         return self.links.subject_sets.remove(subject_sets)
     
     def subject_status(self, subject_id):
-        return SubjectWorkflowStatus.where(subject_id= subject_id, workflow_id=self.id)
+        """
+        Returns an list of SubjectWorkflowStatuses of the current workflow given subject_id
+        """
+        return list(SubjectWorkflowStatus.where(subject_id=subject_id, workflow_id=self.id))
 
     @property
     def versions(self):

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 from builtins import str
 from copy import deepcopy
+from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 
 from panoptes_client.exportable import Exportable
 from panoptes_client.panoptes import PanoptesObject, LinkResolver
@@ -114,6 +115,9 @@ class Workflow(PanoptesObject, Exportable):
         """
 
         return self.links.subject_sets.remove(subject_sets)
+    
+    def subject_status(self, subject_id):
+        return SubjectWorkflowStatus.where(subject_id= subject_id, workflow_id=self.id)
 
     @property
     def versions(self):

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -118,7 +118,11 @@ class Workflow(PanoptesObject, Exportable):
 
     def subject_status(self, subject_id):
         """
-        Returns an SubjectWorkflowStatuses of the current workflow given subject_id
+        Returns SubjectWorkflowStatus of the current workflow given subject_id
+
+        Example::
+
+            workflow.subject_status(1234)
         """
         return next(SubjectWorkflowStatus.where(subject_id=subject_id, workflow_id=self.id))
 


### PR DESCRIPTION
Currently Drafting this Pr:

**Current Changes:**
- shortcut functions on the Workflow resource and the Subject resource to query SubjectWorkflowStatus (These were suggestions on this github issue https://github.com/zooniverse/panoptes-python-client/issues/231)

Not in this PR/changes, but I think it would be nice to have the ability to query SubjectWorkflowStatus by subject_set_id, (i.e. `Workflow.subject_set_status(subject_set_id=YOUR_SS_ID)`, but I think for this change to happen, would have to update the panoptes API route that queries SubjectWorkflowStatus to also be able to accept subject_set_id. Am I off base on this? Would love feedback. 