### PR TITLE
GH action on release 

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,6 @@
 name: Publish to PyPi
 
-on: 
-  release:
-    types: [created]
+on: workflow_dispatch
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,8 @@
 name: Publish to PyPi
 
-on: workflow_dispatch
+on: 
+  release:
+    types: [created]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPi
+
+on: workflow_dispatch
+
+jobs:
+  build-and-publish:
+    name: Build python package and publish to PyPi
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build
+      run: python setup.py sdist bdist_wheel
+    - name: Publish to PyPi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,12 +1,10 @@
-name: Publish to PyPi
+name: Publish to Test PyPi
 
-on: 
-  release:
-    types: [created]
+on: workflow_dispatch
 
 jobs:
   build-and-publish:
-    name: Build python package and publish to PyPi
+    name: Build python package and publish to Test PyPi
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -20,8 +18,9 @@ jobs:
         pip install setuptools wheel
     - name: Build
       run: python setup.py sdist bdist_wheel
-    - name: Publish to PyPi
+    - name: Publish to Test PyPi
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
GH action configuration to twine upload to pypi on new releases. Most of this is following what Coleman set up on this PR https://github.com/zooniverse/aggregation-for-caesar/pull/445. Only difference is that I set it up on release instead of `workflow_dispatch`.  But I can change that if we want. 

- One thing, I'm unsure how to test this. So would love feedback or another set of eyes on this. 
