### PR TITLE
ensure logger handlers are setup

### DIFF
--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -20,6 +20,8 @@ RETRY_BACKOFF_INTERVAL = 5
 
 if os.environ.get('PANOPTES_DEBUG'):
     logging.basicConfig(level=logging.DEBUG)
+else:
+    logging.basicConfig()
 
 
 class Panoptes(object):


### PR DESCRIPTION
avoid no logger handler warnings in python 2.7, https://stackoverflow.com/questions/44188270/no-handlers-could-be-found-for-logger