### PR TITLE
Add copy method to Project resource

### DIFF
--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -196,11 +196,13 @@ class Project(PanoptesObject, Exportable):
             }},
         )
 
-    def copy(self,new_subject_set_name=None):
+    def copy(self, new_subject_set_name=None):
         """
-        Copy this project to a new project that will be owned by the currently authenticated user
+        Copy this project to a new project that will be owned by the
+        currently authenticated user.
 
-        A new_subject_set_name string argument can be passed which will be used to name a new SubjectSet for the copied project.
+        A new_subject_set_name string argument can be passed which will be
+        used to name a new SubjectSet for the copied project.
         This is useful for having an upload target straight after cloning.
 
         Examples::

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -221,12 +221,14 @@ class Project(PanoptesObject, Exportable):
 
         # find the API resource response in the response tuple
         resource_response = response[0]
+        # save the etag from the copied project response
+        etag = response[1]
         # extract the raw copied project resource response
         raw_resource_response = resource_response[self._api_slug][0]
+
         # convert it into a new project model representation
-        copied_project = Project(raw_resource_response)
-        # re-fetch the saved resource to make it savable (etag fetch)
-        copied_project.reload()
+        # ensure we provide the etag - without it the resource won't be savable
+        copied_project = Project(raw_resource_response, etag)
 
         return copied_project
 

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -225,6 +225,8 @@ class Project(PanoptesObject, Exportable):
         raw_resource_response = resource_response[self._api_slug][0]
         # convert it into a new project model representation
         copied_project = Project(raw_resource_response)
+        # re-fetch the saved resource to make it savable (etag fetch)
+        copied_project.reload()
 
         return copied_project
 

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -11,7 +11,6 @@ from panoptes_client.project_role import ProjectRole
 from panoptes_client.exportable import Exportable
 from panoptes_client.utils import batchable
 
-
 class ProjectLinkCollection(LinkCollection):
     def add(self, objs):
         from panoptes_client.workflow import Workflow
@@ -213,10 +212,19 @@ class Project(PanoptesObject, Exportable):
         if new_subject_set_name:
             payload['create_subject_set'] = new_subject_set_name
 
-        return self.http_post(
+        response = self.http_post(
             '{}/copy'.format(self.id),
             json=payload,
         )
+
+        # find the API resource response in the response tuple
+        resource_response = response[0]
+        # extract the raw copied project resource response
+        raw_resource_response = resource_response[self._api_slug][0]
+        # convert it into a new project model representation
+        copied_project = Project(raw_resource_response)
+
+        return copied_project
 
 
 LinkResolver.register(Project)

--- a/panoptes_client/project.py
+++ b/panoptes_client/project.py
@@ -197,6 +197,27 @@ class Project(PanoptesObject, Exportable):
             }},
         )
 
+    def copy(self,new_subject_set_name=None):
+        """
+        Copy this project to a new project that will be owned by the currently authenticated user
+
+        A new_subject_set_name string argument can be passed which will be used to name a new SubjectSet for the copied project.
+        This is useful for having an upload target straight after cloning.
+
+        Examples::
+
+            project.copy()
+            project.copy("My new subject set for uploading")
+        """
+        payload = {}
+        if new_subject_set_name:
+            payload['create_subject_set'] = new_subject_set_name
+
+        return self.http_post(
+            '{}/copy'.format(self.id),
+            json=payload,
+        )
+
 
 LinkResolver.register(Project)
 LinkResolver.register(Project, 'projects')


### PR DESCRIPTION
Linked to https://github.com/zooniverse/panoptes/pull/3740

This PR adds the ability to copy a 'template' project using the API copy end point. 

Example Usage
``` python
project = Project.find(id)

# copy the project
copied_project = project.copy()
pp.pprint(copied_project.raw)

# copy the project and add automatically add a new subject set for uploading
copied_project = project.copy('my new set for uploading')
pp.pprint(copied_project.raw)
```