### PR TITLE
adding save  workflow to caesar method

### DIFF
--- a/panoptes_client/caesar.py
+++ b/panoptes_client/caesar.py
@@ -1,4 +1,4 @@
-from panoptes_client.panoptes import Panoptes
+from panoptes_client.panoptes import Panoptes, PanoptesAPIException
 
 
 class Caesar(object):
@@ -80,14 +80,16 @@ class Caesar(object):
 
     def save_workflow(self, workflow_id, public_extracts=False, public_reductions=False):
         """
-        Adds/updates workflow with provided workflow_id to Caesar. Returns workflow as a dict from Caesar if created.
+        Adds/updates workflow with provided workflow_id to Caesar. Checks to see if workflow exists in Caesar, if not
+        then creates workflow and returns workflow as a dict from Caesar if created.
+        If workflow is already in Caesar, will update the Caesar workflow.
 
         Examples::
-            Caesar().add_workflow(123, public_extracts=True, public_reductions=True)
+            Caesar().save_workflow(123, public_extracts=True, public_reductions=True)
         """
         try:
             self.get_workflow(workflow_id)
-        except Exception as err:
+        except PanoptesAPIException as err:
             if "couldn't find workflow with 'id'" in str(err).lower():
                 return self.http_post('workflows', json={
                     'workflow': {

--- a/panoptes_client/caesar.py
+++ b/panoptes_client/caesar.py
@@ -97,7 +97,6 @@ class Caesar(object):
                     }
                 })[0]
             else:
-                print(err)
                 raise err
         else:
             return self.http_put(f'workflows/{workflow_id}', json={

--- a/panoptes_client/caesar.py
+++ b/panoptes_client/caesar.py
@@ -46,7 +46,7 @@ class Caesar(object):
     def http_delete(self, *args, **kwargs):
         kwargs['endpoint'] = self.endpoint
         return Panoptes.client().delete(*args, **kwargs)
-    
+
     def get_workflow(self, workflow_id):
         """
         Returns workflow object if exists in Caesar

--- a/panoptes_client/caesar.py
+++ b/panoptes_client/caesar.py
@@ -37,11 +37,21 @@ class Caesar(object):
 
     def http_put(self, *args, **kwargs):
         kwargs['endpoint'] = self.endpoint
+        kwargs['headers'] = {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+        }
         return Panoptes.client().put(*args, **kwargs)
 
     def http_delete(self, *args, **kwargs):
         kwargs['endpoint'] = self.endpoint
         return Panoptes.client().delete(*args, **kwargs)
+    
+    def get_workflow(self, workflow_id):
+        """
+        Returns workflow object if exists in Caesar
+        """
+        return self.http_get(f'workflows/{workflow_id}')[0]
 
     def get_reductions_by_workflow_and_subject(self, workflow_id, subject_id):
         """
@@ -68,20 +78,35 @@ class Caesar(object):
         return self.http_get(
             f'workflows/{workflow_id}/extractors/extractor/extracts', params={'subject_id': subject_id})[0]
 
-    def add_workflow(self, workflow_id, public_extracts=False, public_reductions=False):
+    def save_workflow(self, workflow_id, public_extracts=False, public_reductions=False):
         """
-        Adds workflow with provided workflow_id to Caesar. Returns workflow as a dict from Caesar if successful.
+        Adds/updates workflow with provided workflow_id to Caesar. Returns workflow as a dict from Caesar if created.
 
         Examples::
             Caesar().add_workflow(123, public_extracts=True, public_reductions=True)
         """
-        return self.http_post('workflows', json={
-            'workflow': {
-                'id': workflow_id,
-                'public_extracts': public_extracts,
-                'public_reductions': public_reductions
-            }
-        })[0]
+        try:
+            self.get_workflow(workflow_id)
+        except Exception as err:
+            if "couldn't find workflow with 'id'" in str(err).lower():
+                return self.http_post('workflows', json={
+                    'workflow': {
+                        'id': workflow_id,
+                        'public_extracts': public_extracts,
+                        'public_reductions': public_reductions
+                    }
+                })[0]
+            else:
+                print(err)
+                raise err
+        else:
+            return self.http_put(f'workflows/{workflow_id}', json={
+                'workflow': {
+                    'id': workflow_id,
+                    'public_extracts': public_extracts,
+                    'public_reductions': public_reductions
+                }
+            })[0]
 
     def create_workflow_extractor(self, workflow_id, extractor_key,
                                   extractor_type, task_key='T0', other_extractor_attributes=None):

--- a/panoptes_client/tests/test_workflow.py
+++ b/panoptes_client/tests/test_workflow.py
@@ -1,5 +1,6 @@
 import unittest
 import sys
+from panoptes_client.panoptes import PanoptesAPIException
 from panoptes_client.workflow import Workflow
 from panoptes_client.caesar import Caesar
 
@@ -14,18 +15,35 @@ class TestWorkflow(unittest.TestCase):
     def setUp(self):
         super().setUp()
         caesar_post_patch = patch.object(Caesar, 'http_post')
+        caesar_put_patch = patch.object(Caesar, 'http_put')
         caesar_get_patch = patch.object(Caesar, 'http_get')
         self.caesar_post_mock = caesar_post_patch.start()
+        self.caesar_put_mock = caesar_put_patch.start()
         self.caesar_get_mock = caesar_get_patch.start()
         self.addCleanup(caesar_post_patch.stop)
         self.addCleanup(caesar_get_patch.stop)
+        self.addCleanup(caesar_put_patch.stop)
 
-    def test_add_to_caesar(self):
+    def test_save_to_caesar_update(self):
         workflow = Workflow(1)
-        workflow.add_to_caesar()
+        workflow.save_to_caesar()
+        
+        self.caesar_put_mock.assert_called_once()
+        self.caesar_put_mock.assert_called_with('workflows/1', json={
+            'workflow': {
+                'id': workflow.id,
+                'public_extracts': False,
+                'public_reductions': False
+            }
+        })
+
+    def test_save_to_caesar_create(self):
+        self.caesar_get_mock.side_effect = PanoptesAPIException("Couldn't find Workflow with 'id'=1")
+
+        workflow = Workflow(1)
+        workflow.save_to_caesar()
 
         self.caesar_post_mock.assert_called_once()
-
         self.caesar_post_mock.assert_called_with('workflows', json={
             'workflow': {
                 'id': workflow.id,
@@ -33,6 +51,16 @@ class TestWorkflow(unittest.TestCase):
                 'public_reductions': False
             }
         })
+
+    def test_save_to_caesar_raises_err(self):
+        self.caesar_get_mock.side_effect = PanoptesAPIException("Some other error not workflow_id missing error")
+
+        with self.assertRaises(PanoptesAPIException):
+            workflow = Workflow(1)
+            workflow.save_to_caesar()
+
+        self.caesar_post_mock.assert_not_called()
+        self.caesar_put_mock.assert_not_called()
 
     def test_caesar_subject_extracts(self):
         workflow = Workflow(1)

--- a/panoptes_client/tests/test_workflow.py
+++ b/panoptes_client/tests/test_workflow.py
@@ -27,7 +27,7 @@ class TestWorkflow(unittest.TestCase):
     def test_save_to_caesar_update(self):
         workflow = Workflow(1)
         workflow.save_to_caesar()
-        
+
         self.caesar_put_mock.assert_called_once()
         self.caesar_put_mock.assert_called_with('workflows/1', json={
             'workflow': {

--- a/panoptes_client/workflow.py
+++ b/panoptes_client/workflow.py
@@ -184,25 +184,18 @@ class Workflow(PanoptesObject, Exportable):
 
     """ CAESAR METHODS """
 
-    def add_to_caesar(self, public_extracts=False, public_reductions=False):
+    def save_to_caesar(self, public_extracts=False, public_reductions=False):
         """
-        Adds selected Workflow to Caesar. Returns workflow as a dict from Caesar if successful.
+        Adds/updates selected Workflow to Caesar. Returns workflow as a dict from Caesar if created.
         - **public_extracts** set to True to Enable Public Extracts, Defaults to False
         - **public_reductions** set to True to Enable Public Reductions. Defaults to False
 
         Examples::
-            workflow.add_to_caesar()
-            workflow.add_to_caesar(public_extracts=True, public_reductions=True)
+            workflow.save_to_caesar()
+            workflow.save_to_caesar(public_extracts=True, public_reductions=True)
 
         """
-        payload = {
-            'workflow': {
-                'id': self.id,
-                'public_extracts': public_extracts,
-                'public_reductions': public_reductions
-            }
-        }
-        return Caesar().http_post(self._api_slug, json=payload)[0]
+        return Caesar().save_workflow(self.id, public_extracts, public_reductions)
 
     def caesar_subject_extracts(self, subject_id):
         """
@@ -515,7 +508,7 @@ class Workflow(PanoptesObject, Exportable):
         (In particular, Question-based retirement's retirement limit is 3 and Count-based retirement default is 30.)
 
         """
-        self.add_to_caesar(public_extracts=True, public_reductions=True)
+        self.save_to_caesar(public_extracts=True, public_reductions=True)
         self.add_alice_extractors()
         self.add_alice_reducers()
         self.add_alice_rules_and_effects()


### PR DESCRIPTION
Updated `add_to_caesar` method to `save_to_caesar` which will check if workflow exists in caesar first, if it does, then update, if it doesn't exist in caesar, then create. 