### PR TITLE
Update Docs: use HTTPS for git-based install command

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -45,7 +45,7 @@ Install latest stable release::
 Or for development or testing, you can install the development version directly
 from GitHub::
 
-    $ pip install -U git+git://github.com/zooniverse/panoptes-python-client.git
+    $ pip install -U git+https://github.com/zooniverse/panoptes-python-client.git
 
 Upgrade an existing installation::
 


### PR DESCRIPTION
Same as #225, updating the direct-from-github `pip` install command to use HTTPS instead of no-longer-support `git+git` method.