### PR TITLE
Autopopulate Caesar entries in docs

### DIFF
--- a/docs/panoptes_client.rst
+++ b/docs/panoptes_client.rst
@@ -115,3 +115,10 @@ panoptes\_client\.workflow\_version module
     :undoc-members:
     :show-inheritance:
     :exclude-members: http_get
+
+panoptes\_client\.Caesar module
+------------------------------------------
+
+.. automodule:: panoptes_client.workflow_version
+    :members:
+    :show-inheritance:


### PR DESCRIPTION
Edit `panoptes_client.rst` to autopopulate Caesar entries on doc page. Builds on https://github.com/zooniverse/panoptes-python-client/pull/274/commits/59772ddb3ad8fedb6d888f28dd52d23989bbe44b.

Copied format of other classes, but did not confirm this fix works.