### PR TITLE
bug fix: doc links for caesar

### DIFF
--- a/docs/panoptes_client.rst
+++ b/docs/panoptes_client.rst
@@ -116,9 +116,9 @@ panoptes\_client\.workflow\_version module
     :show-inheritance:
     :exclude-members: http_get
 
-panoptes\_client\.Caesar module
+panoptes\_client\.caesar module
 ------------------------------------------
 
-.. automodule:: panoptes_client.workflow_version
+.. automodule:: panoptes_client.caesar
     :members:
     :show-inheritance:


### PR DESCRIPTION
Edit panoptes_client.rst to autopopulate Caesar entries on doc page. Builds on https://github.com/zooniverse/panoptes-python-client/commit/adf08ecad05482f53fb53fc889cd7aa90e44b7b8.

ReadTheDocs was not correct; this should help.