### PR TITLE
bug fix: doc links for caesar (v2)

### DIFF
--- a/docs/panoptes_client.rst
+++ b/docs/panoptes_client.rst
@@ -117,7 +117,7 @@ panoptes\_client\.workflow\_version module
     :exclude-members: http_get
 
 panoptes\_client\.caesar module
-------------------------------------------
+-------------------------------
 
 .. automodule:: panoptes_client.caesar
     :members:


### PR DESCRIPTION
Edit panoptes_client.rst to autopopulate Caesar entries on doc page. Builds on https://github.com/zooniverse/panoptes-python-client/commit/219a4789298cff1a95c43de20aac50a01609d830

ReadTheDocs was not correct; this should help.  Third try.