### PR TITLE
Ensure LICENSE is included in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This change ensures the `LICENSE` file is uploaded along with the source distribution on PyPI.

The motivation is in getting a [`conda-forge`](https://conda-forge.org/) automated build chain established, and license-box-ticking is one of the "brown m&ms" for well-behaved packages.

I will proceed sourcing it directly from GitHub in the meantime!

## References
- https://github.com/zooniverse/aggregation-for-caesar/pull/621