### PR TITLE
Add iNaturalist class & import method

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -307,7 +307,24 @@ already known::
         settings=new_settings,
     )
 
-Other examples (Caesar features by Workflow)
+Importing iNaturalist observations to Panoptes as subjects is possible via an
+API endpoint. Project owners and collaborators can use this client to send
+a request to begin that import process::
+
+    # The ID of the iNat taxon to be imported
+    taxon_id = 1234
+
+    # The subject set to which new subjects will be added
+    subject_set_id = 5678
+
+    Inaturalist.inat_import(taxon_id, subject_set_id)
+
+As an optional parameter, the updated_since timestamp string can be included
+and will filter obeservations by that parameter::
+
+    Inaturalist.inat_import(taxon_id, subject_set_id, '2022-10-31')
+
+Other examples Caesar features by Workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Most Caesar use cases are usually through a workflow: the following are examples of Caesar functions that can be done via Workflow.
 

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -324,6 +324,11 @@ and will filter obeservations by that parameter::
 
     Inaturalist.inat_import(taxon_id, subject_set_id, '2022-10-31')
 
+Be aware that this command only initiates a background job on the Zooniverse
+to import Observations. You can refresh the subject set in the project builder
+to see how far along it is, and the authenticated user will receive an email
+when this job is completed.
+
 Other examples Caesar features by Workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Most Caesar use cases are usually through a workflow: the following are examples of Caesar functions that can be done via Workflow.

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -325,7 +325,8 @@ and will filter obeservations by that parameter::
     Inaturalist.inat_import(taxon_id, subject_set_id, '2022-10-31')
 
 Be aware that this command only initiates a background job on the Zooniverse
-to import Observations. You can refresh the subject set in the project builder
+to import Observations. The request will return a 200 upon success, but there
+is no progress to observe. You can refresh the subject set in the project builder
 to see how far along it is, and the authenticated user will receive an email
 when this job is completed.
 

--- a/panoptes_client/__init__.py
+++ b/panoptes_client/__init__.py
@@ -12,4 +12,3 @@ from panoptes_client.user import User
 from panoptes_client.workflow import Workflow
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 from panoptes_client.caesar import Caesar
-from panoptes_client.inaturalist import Inaturalist

--- a/panoptes_client/__init__.py
+++ b/panoptes_client/__init__.py
@@ -12,3 +12,4 @@ from panoptes_client.user import User
 from panoptes_client.workflow import Workflow
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 from panoptes_client.caesar import Caesar
+from panoptes_client.inaturalist import Inaturalist

--- a/panoptes_client/inaturalist.py
+++ b/panoptes_client/inaturalist.py
@@ -38,11 +38,5 @@ class Inaturalist(object):
                 'taxon_id': taxon_id,
                 'subject_set_id': subject_set_id,
                 'updated_since': updated_since
-            },
-            headers={
-                'Accept': 'application/vnd.api+json; version=1',
-                'Content-Type': 'application/json'
-            },
-            endpoint='http://localhost:3000',
-            retry=False
+            }
         )

--- a/panoptes_client/inaturalist.py
+++ b/panoptes_client/inaturalist.py
@@ -33,7 +33,7 @@ class Inaturalist(object):
         """
 
         return Panoptes.client().post(
-            f'api/inaturalist/import',
+            f'/inaturalist/import',
             json={
                 'taxon_id': taxon_id,
                 'subject_set_id': subject_set_id,

--- a/panoptes_client/inaturalist.py
+++ b/panoptes_client/inaturalist.py
@@ -34,7 +34,7 @@ class Inaturalist(object):
 
         return Panoptes.client().post(
             f'api/inaturalist/import',
-            json= {
+            json={
                 'taxon_id': taxon_id,
                 'subject_set_id': subject_set_id,
                 'updated_since': updated_since

--- a/panoptes_client/inaturalist.py
+++ b/panoptes_client/inaturalist.py
@@ -1,5 +1,6 @@
 from panoptes_client.panoptes import Panoptes
 
+
 class Inaturalist(object):
     """
     The class that interacts with the Panoptes' iNaturalist functionality.
@@ -30,7 +31,6 @@ class Inaturalist(object):
             # Import all royal flycatcher observations to subject set id 4:
             Inaturalist.inat_import(16462, 4)
         """
-
 
         return Panoptes.client().post(
             f'api/inaturalist/import',

--- a/panoptes_client/inaturalist.py
+++ b/panoptes_client/inaturalist.py
@@ -1,0 +1,48 @@
+from panoptes_client.panoptes import Panoptes
+
+class Inaturalist(object):
+    """
+    The class that interacts with the Panoptes' iNaturalist functionality.
+    Currently, this includes a single route that allows the importing of
+    iNaturalist Observations as Zooniverse Subjects.
+    """
+
+    def inat_import(
+        taxon_id,
+        subject_set_id,
+        updated_since=None
+    ):
+        """
+        Begins an import of iNaturalist Observations as Zooniverse Subjects.
+        Response is a 200 if Panoptes begins the import successfully.
+        Requires owner or collaborator access to the subject set's linked project.
+        Takes three arguments:
+            taxon_id:       the iNat taxon ID of a particular species
+            subject_set_id: the Zoo subject set id subjects should be imported into.
+                            Updated observations will upsert their respective subjects.
+            updated_since:  a date range limiter on the iNat Observations query.
+                            Warning: defaults to None and will import ALL Observations
+                            by default. This will likely be a lot and take a while.
+        Examples::
+            # Import gray squirrel observations updated during or after Halloween 2022 to subject set id 3:
+            Inaturalist.inat_import(46017, 3, '2022-10-31')
+
+            # Import all royal flycatcher observations to subject set id 4:
+            Inaturalist.inat_import(16462, 4)
+        """
+
+
+        return Panoptes.client().post(
+            f'api/inaturalist/import',
+            json= {
+                'taxon_id': taxon_id,
+                'subject_set_id': subject_set_id,
+                'updated_since': updated_since
+            },
+            headers={
+                'Accept': 'application/vnd.api+json; version=1',
+                'Content-Type': 'application/json'
+            },
+            endpoint='http://localhost:3000',
+            retry=False
+        )

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -13,27 +13,28 @@ from panoptes_client.inaturalist import Inaturalist
 
 class TestInaturalist(unittest.TestCase):
 
+
     def test_inat_import(self):
-        with patch('panoptes_client.panoptes.Panoptes') as pc:
-            pc.client().post = Mock(return_value=200)
+        with patch('panoptes_client.panoptes.Panoptes.client') as pc:
+            pc().post = Mock(return_value=200)
             Inaturalist.inat_import(16462, 4)
 
-            pc.client().post.assert_called_with(
-                '/api/inaturalist/import',
+            pc().post.assert_called_with(
+                'api/inaturalist/import',
                 json={
                     'taxon_id': 16462,
                     'subject_set_id': 4,
                     'updated_since': None
-                },
+                }
             )
 
     def test_inat_import_updated_since(self):
-        with patch('panoptes_client.panoptes.Panoptes') as pc:
-            pc.client().json_request = Mock(return_value=200)
+        with patch('panoptes_client.panoptes.Panoptes.client') as pc:
+            pc().post = Mock(return_value=200)
             Inaturalist.inat_import(16462, 4, '2022-10-31')
 
-            pc.client().post.assert_called_with(
-                '/api/inaturalist/import',
+            pc().post.assert_called_with(
+                'api/inaturalist/import',
                 json={
                     'taxon_id': 16462,
                     'subject_set_id': 4,

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+import sys
+
+if sys.version_info <= (3, 0):
+    from mock import patch, Mock
+else:
+    from unittest.mock import patch, Mock
+
+from panoptes_client.inaturalist import Inaturalist
+
+class TestInaturalist(unittest.TestCase):
+    def test_inat_import(self):
+        with patch('panoptes_client.panoptes.Panoptes') as pc:
+            pc.client().post = Mock(return_value=200)
+            Inaturalist.inat_import(16462, 4)
+
+            pc.client().post.assert_called_with(
+                '/api/inaturalist/import',
+                json={
+                    'taxon_id': 16462,
+                    'subject_set_id': 4,
+                    'updated_since': None
+                },
+        )
+
+    def test_inat_import_updated_since(self):
+        with patch('panoptes_client.panoptes.Panoptes') as pc:
+            pc.client().json_request = Mock(return_value=200)
+            Inaturalist.inat_import(16462, 4, '2022-10-31')
+
+            pc.client().post.assert_called_with(
+                '/api/inaturalist/import',
+                json={
+                    'taxon_id': 16462,
+                    'subject_set_id': 4,
+                    'updated_since': '2022-10-31'
+                }
+            )

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -19,7 +19,7 @@ class TestInaturalist(unittest.TestCase):
             Inaturalist.inat_import(16462, 4)
 
             pc().post.assert_called_with(
-                'api/inaturalist/import',
+                '/inaturalist/import',
                 json={
                     'taxon_id': 16462,
                     'subject_set_id': 4,
@@ -33,7 +33,7 @@ class TestInaturalist(unittest.TestCase):
             Inaturalist.inat_import(16462, 4, '2022-10-31')
 
             pc().post.assert_called_with(
-                'api/inaturalist/import',
+                '/inaturalist/import',
                 json={
                     'taxon_id': 16462,
                     'subject_set_id': 4,

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -10,6 +10,7 @@ else:
 
 from panoptes_client.inaturalist import Inaturalist
 
+
 class TestInaturalist(unittest.TestCase):
 
     def test_inat_import(self):

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -11,6 +11,7 @@ else:
 from panoptes_client.inaturalist import Inaturalist
 
 class TestInaturalist(unittest.TestCase):
+
     def test_inat_import(self):
         with patch('panoptes_client.panoptes.Panoptes') as pc:
             pc.client().post = Mock(return_value=200)
@@ -23,7 +24,7 @@ class TestInaturalist(unittest.TestCase):
                     'subject_set_id': 4,
                     'updated_since': None
                 },
-        )
+            )
 
     def test_inat_import_updated_since(self):
         with patch('panoptes_client.panoptes.Panoptes') as pc:

--- a/panoptes_client/tests/test_inaturalist.py
+++ b/panoptes_client/tests/test_inaturalist.py
@@ -13,7 +13,6 @@ from panoptes_client.inaturalist import Inaturalist
 
 class TestInaturalist(unittest.TestCase):
 
-
     def test_inat_import(self):
         with patch('panoptes_client.panoptes.Panoptes.client') as pc:
             pc().post = Mock(return_value=200)


### PR DESCRIPTION
Adds a simple iNaturalist object that has a single method. That method sends a POST request to Panoptes that starts an iNat Observation import. It uses the base `Panoptes.client()` POST method, which includes authentication. 

~I've included two tests which are currently failing--I can't figure out why the mock isn't working. The SubjectSet test was the model and it sure seems to me that they that method should be stubbed and not actually trying to call out. It's a simple enough test that it might be easier to just remove it, but let me know if I'm missing something obvious.~

Tests are sorted, I forgot to remove some dev/debug stuff. Thanks @yuenmichelle1 