### PR TITLE
Fixing 409 crashes

### DIFF
--- a/panoptes_client/subject_set.py
+++ b/panoptes_client/subject_set.py
@@ -94,6 +94,9 @@ class SubjectSet(PanoptesObject, Exportable):
             subject_set.links.add(subjects)
         """
 
+        # reload the subject set to make sure the online version not stale
+        self.reload()
+
         return self.links.subjects.add(subjects)
 
     def remove(self, subjects):


### PR DESCRIPTION
There have been a few soft crashes with subject uploads, leading to the question of whether the async subject upload was causing issues. I've added a new non-asynchronous save method which appears to be more stable.

One other issue was when Panoptes would throw a `409: Attempted to update a stale object: SubjectSet.` when updating subject sets with uploaded subjects. I've added a condition to the request to retry on a `409` error, which has fixed this issue.
