### PR TITLE
Remove max limit on dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,15 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'requests>=2.4.2,<2.29',
-        'future>=0.16,<0.19',
-        'python-magic>=0.4,<0.5',
+        'requests>=2.4.2,
+        'future>=0.16',
+        'python-magic>=0.4',
         'redo>=1.7',
         'six>=1.9',
     ],
     extras_require={
         'testing': [
-            'mock>=2.0,<5.2',
+            'mock>=2.0',
         ],
         'docs': [
             'sphinx',


### PR DESCRIPTION
Brief Slack discussion ([link to thread](https://zooniverse.slack.com/archives/C1RML6TGT/p1696262191305079)) with @adammcmaster confirmed that there was no specific issue dictating max limits on dependency versions (added in #129). To limit dependency version conflicts, I propose we remove these limits until a point where a specific max limit is required for any of the dependencies. We have received multiple reports (e.g., from [Spyfish Aotearoa](https://www.zooniverse.org/projects/victorav/spyfish-aotearoa) and [Gravity Spy](https://www.zooniverse.org/projects/zooniverse/gravity-spy) teams) of max version on `requests` library causing issues and incompatibilities.

Closes #301 as that sort of bump would no longer be required.