### PR TITLE
Add support for SubjectSet metadata as editable attribute

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -215,8 +215,6 @@ class Subject(PanoptesObject):
         super(Subject, self).set_raw(raw, etag, loaded)
         if loaded and self.metadata:
             self._original_metadata = deepcopy(self.metadata)
-        elif loaded:
-            self._original_metadata = None
 
     def subject_workflow_status(self, workflow_id):
         """

--- a/panoptes_client/subject_set.py
+++ b/panoptes_client/subject_set.py
@@ -76,8 +76,6 @@ class SubjectSet(PanoptesObject, Exportable):
         super(SubjectSet, self).set_raw(raw, etag, loaded)
         if loaded and self.metadata:
             self._original_metadata = deepcopy(self.metadata)
-        elif loaded:
-            self._original_metadata = None
 
     def save(self):
         """

--- a/panoptes_client/subject_set.py
+++ b/panoptes_client/subject_set.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 from builtins import str
+from copy import deepcopy
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 
 from panoptes_client.panoptes import (
@@ -56,16 +57,37 @@ class SubjectSet(PanoptesObject, Exportable):
     _link_slug = 'subject_sets'
     _edit_attributes = (
         'display_name',
+        'metadata',
         {
             'links': (
                 'project',
-            ),
-            'metadata': (
-                'category',
             )
         },
     )
     _link_collection = SubjectSetLinkCollection
+
+    def __init__(self, raw={}, etag=None):
+        super(SubjectSet, self).__init__(raw, etag)
+        if not self.metadata:
+            self.metadata = {}
+            self._original_metadata = {}
+
+    def set_raw(self, raw, etag=None, loaded=True):
+        super(SubjectSet, self).set_raw(raw, etag, loaded)
+        if loaded and self.metadata:
+            self._original_metadata = deepcopy(self.metadata)
+        elif loaded:
+            self._original_metadata = None
+
+    def save(self):
+        """
+        Adds workflow configuration, retirement, and tasks dicts to the list of
+        savable attributes if it has changed.
+        """
+        if not self.metadata == self._original_metadata:
+            self.modified_attributes.add('metadata')
+
+        super(SubjectSet, self).save()
 
     @property
     def subjects(self):

--- a/panoptes_client/subject_set.py
+++ b/panoptes_client/subject_set.py
@@ -81,7 +81,7 @@ class SubjectSet(PanoptesObject, Exportable):
 
     def save(self):
         """
-        Adds workflow configuration, retirement, and tasks dicts to the list of
+        Adds subject set metadata dict to the list of
         savable attributes if it has changed.
         """
         if not self.metadata == self._original_metadata:

--- a/panoptes_client/tests/test_subject_set.py
+++ b/panoptes_client/tests/test_subject_set.py
@@ -33,6 +33,7 @@ class TestSubjectSet(unittest.TestCase):
                 json={
                     'subject_sets': {
                         'display_name': 'Name',
+                        'metadata': {},
                         'links': {
                             'project': 1234,
                         }


### PR DESCRIPTION
Closes https://github.com/zooniverse/panoptes-cli/issues/256

The issue: when `SubjectSet.metadata` attribute is edited, there is no check for changes in that field, so it is never added to `modified_attributes` set and therefore those edits were never pushed as a result of the `save()` call.

Following same solution as in #222 and #251 for workflow and project attributes:
- add code to initialize current vs original check of metadata dict in `set_raw` and `__init__` functions
- add check to `save()` to add metadata attribute to `modified_attributes` if contents are different

Note on change in treatment of `SubjectSet.metadata` field: I've changed `metadata` to a standalone key in `SubjectSet._edit_attributes` field as opposed to dict similar to `links` field.  The distinction between these two treatments of the attribute occur in `PanoptesObject._savable_dict()` (see https://github.com/zooniverse/panoptes-python-client/blob/master/panoptes_client/panoptes.py#L759-L793), but I'm following the precedent already used by `Subject` class and elsewhere for these dict attribute fields.

Note on CLI issue: although treatment of SubjectSet metadata has been implemented in the CLI for ~2 years (since https://github.com/zooniverse/panoptes-cli/pull/214), it looks like this feature -- identifying and flagging indexed fields by adding them to `indexFields` key in SubjectSet metadata -- has never worked up to this point.

This PR currently needs testing: 
- [ ] check that metadata edits behave as expected
- [ ] check that CLI issue is in fact resolved