### PR TITLE
modify user guide to have Project copier and Data exports in other examples

### DIFF
--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -381,3 +381,73 @@ Adding Subject Rules by Workflow. When creating a rule, the `condition_string` a
 Adding Subject Effect for a Subject Rule with id `1234` by Workflow. Ths particular effect being created will retire subjects early due to a consensus. ::
 
     workflow.add_caesar_rule_effect('subject', 1234, 'retire_subject', {'reason' : 'consensus'})
+
+Other examples Project Copier
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The project copier feature clones an existing template project (i.e., projects which have the project.configuration `template` flag set as true and are not live).
+
+You can set the template flag using the Project.save() method. See example below:::
+
+    project = Project(project_id)
+    project.configuration = {"template": True}
+    project.save()
+
+How to use::
+This functionality can be accessed by the Panoptes python client. It exists on the Project module and can be called with the `copy` method.
+
+    Project(project_id).copy()
+
+You can also pass an optional `new_subject_set_name` parameter and this would be used to create a new SubjectSet for the newly cloned project::
+
+    Project(project_id).copy(new_subject_set_name='My New Subject Set')
+
+Other examples Programmatic Data Exports
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The Panoptes Python Client allows you to generate, describe, and download data exports (e.g., classifications, subjects, workflows) via the Python ``panoptes_client`` library.
+
+Multiple types of exports can be generated using the Python Client, including project-level products (classifications, subjects, workflows) as smaller scale classification exports (for workflows and subject sets).
+For the examples below, we will demonstrate commands for a project wide classifications export, but these functions work for any export type.
+
+Get Exports
+--------------
+
+As the name implies, this method downloads a data export over HTTP. This uses the `get_export` method and can be called by passing in the following parameters::
+    export_type #string specifying which type of export should be downloaded
+    generate #a boolean specifying if to generate a new export and wait for it to be ready, or to just download the latest existing export
+    wait #a boolean specifying whether to wait for an in-progress export to finish, if there is one. Has no effect if generate is true.
+    wait_timeout #is the number of seconds to wait if wait is True. Has no effect if wait is False or if generate is True.
+
+    classification_export = Project(project_id).get_export(export_type="classifications")
+
+The returned Response object has two additional attributes as a convenience for working with the CSV content; `csv_reader` and `csv_dictreader`, which are wrappers for `csv.reader()` and `csv.DictReader` respectively.
+These wrappers take care of correctly decoding the export content for the CSV parser
+
+    classification_export = Project(1234).get_export('classifications')
+    for row in classification_export.csv_dictreader():
+    print(row)
+
+Get Exports
+--------------
+As the name implies, this method generates/starts a data export. This uses the `generate_export` method and can be called by passing in the `export_type` parameter::
+
+    export_info = Project(project_id).generate_export(export_type='classifications')
+
+This would return `export_info` as a dictionary containing the metadata on the selected export
+
+Wait Exports
+--------------
+As the name implies, this method blocks/waits until an in-progress export is ready. It uses the `wait_export` method and can be called passing the following parameters::
+    export_type #string specifying which type of export should be downloaded
+    timeout #is the maximum number of seconds to wait.
+
+    export_info = Project(project_id).wait_export(export_type='classifications')
+
+This would return `export_info` as a dictionary containing the metadata on the selected export and throw a `PanoptesAPIException` once the time limit is exceeded and the export is not ready
+
+Describing Exports
+--------------
+This method fetches information/metadata about a specific type of export. This uses the `describe_export` method and can be called by passing in the export_type(classifications, subject_sets) this way::
+
+    export_info = Project(project_id).describe_export(export_type='classifications')
+
+This would return `export_info` as a dictionary containing the metadata on the selected export

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -386,14 +386,14 @@ Other examples Project Copier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The project copier feature clones an existing template project (i.e., projects which have the project.configuration `template` flag set as true and are not live).
 
-You can set the template flag using the Project.save() method. See example below:::
+You can set the template flag using the Project.save() method. See example below::
 
     project = Project(project_id)
     project.configuration = {"template": True}
     project.save()
 
 How to use::
-This functionality can be accessed by the Panoptes python client. It exists on the Project module and can be called with the `copy` method.
+This functionality can be accessed by the Panoptes python client. It exists on the Project module and can be called with the `copy` method::
 
     Project(project_id).copy()
 
@@ -412,15 +412,19 @@ Get Exports
 --------------
 
 As the name implies, this method downloads a data export over HTTP. This uses the `get_export` method and can be called by passing in the following parameters::
+
     export_type #string specifying which type of export should be downloaded
+
     generate #a boolean specifying if to generate a new export and wait for it to be ready, or to just download the latest existing export
+
     wait #a boolean specifying whether to wait for an in-progress export to finish, if there is one. Has no effect if generate is true.
+
     wait_timeout #is the number of seconds to wait if wait is True. Has no effect if wait is False or if generate is True.
 
     classification_export = Project(project_id).get_export(export_type="classifications")
 
 The returned Response object has two additional attributes as a convenience for working with the CSV content; `csv_reader` and `csv_dictreader`, which are wrappers for `csv.reader()` and `csv.DictReader` respectively.
-These wrappers take care of correctly decoding the export content for the CSV parser
+These wrappers take care of correctly decoding the export content for the CSV parser::
 
     classification_export = Project(1234).get_export('classifications')
     for row in classification_export.csv_dictreader():
@@ -437,7 +441,9 @@ This would return `export_info` as a dictionary containing the metadata on the s
 Wait Exports
 --------------
 As the name implies, this method blocks/waits until an in-progress export is ready. It uses the `wait_export` method and can be called passing the following parameters::
+
     export_type #string specifying which type of export should be downloaded
+    
     timeout #is the maximum number of seconds to wait.
 
     export_info = Project(project_id).wait_export(export_type='classifications')

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -392,7 +392,8 @@ You can set the template flag using the Project.save() method. See example below
     project.configuration = {"template": True}
     project.save()
 
-How to use::
+How to use
+~~~~~~~~~~
 This functionality can be accessed by the Panoptes python client. It exists on the Project module and can be called with the `copy` method::
 
     Project(project_id).copy()
@@ -409,7 +410,7 @@ Multiple types of exports can be generated using the Python Client, including pr
 For the examples below, we will demonstrate commands for a project wide classifications export, but these functions work for any export type.
 
 Get Exports
---------------
+~~~~~~~~~~~
 
 As the name implies, this method downloads a data export over HTTP. This uses the `get_export` method and can be called by passing in the following parameters::
 
@@ -430,8 +431,8 @@ These wrappers take care of correctly decoding the export content for the CSV pa
     for row in classification_export.csv_dictreader():
     print(row)
 
-Get Exports
---------------
+Generate Exports
+~~~~~~~~~~~~~~~
 As the name implies, this method generates/starts a data export. This uses the `generate_export` method and can be called by passing in the `export_type` parameter::
 
     export_info = Project(project_id).generate_export(export_type='classifications')
@@ -439,11 +440,11 @@ As the name implies, this method generates/starts a data export. This uses the `
 This would return `export_info` as a dictionary containing the metadata on the selected export
 
 Wait Exports
---------------
+~~~~~~~~~~~~
 As the name implies, this method blocks/waits until an in-progress export is ready. It uses the `wait_export` method and can be called passing the following parameters::
 
     export_type #string specifying which type of export should be downloaded
-    
+
     timeout #is the maximum number of seconds to wait.
 
     export_info = Project(project_id).wait_export(export_type='classifications')
@@ -451,7 +452,7 @@ As the name implies, this method blocks/waits until an in-progress export is rea
 This would return `export_info` as a dictionary containing the metadata on the selected export and throw a `PanoptesAPIException` once the time limit is exceeded and the export is not ready
 
 Describing Exports
---------------
+~~~~~~~~~~~~~~~~~~
 This method fetches information/metadata about a specific type of export. This uses the `describe_export` method and can be called by passing in the export_type(classifications, subject_sets) this way::
 
     export_info = Project(project_id).describe_export(export_type='classifications')

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -331,6 +331,8 @@ directly if already known::
         user=user_id
     )
 
+iNaturalist Imports
+~~~~~~~~~~~~~~~~~~~
 Importing iNaturalist observations to Panoptes as subjects is possible via an
 API endpoint. Project owners and collaborators can use this client to send
 a request to begin that import process::
@@ -354,8 +356,8 @@ is no progress to observe. You can refresh the subject set in the project builde
 to see how far along it is, and the authenticated user will receive an email
 when this job is completed.
 
-Other examples Caesar features by Workflow
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Caesar features by Workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Most Caesar use cases are usually through a workflow: the following are examples of Caesar functions that can be done via Workflow.
 
 Add Caesar Extractor by Workflow::
@@ -382,8 +384,8 @@ Adding Subject Effect for a Subject Rule with id `1234` by Workflow. Ths particu
 
     workflow.add_caesar_rule_effect('subject', 1234, 'retire_subject', {'reason' : 'consensus'})
 
-Other examples Project Copier
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Project Copier
+~~~~~~~~~~~~~~
 The project copier feature clones an existing template project (i.e., projects which have the project.configuration `template` flag set as true and are not live).
 
 You can set the template flag using the Project.save() method. See example below::
@@ -402,8 +404,8 @@ You can also pass an optional `new_subject_set_name` parameter and this would be
 
     Project(project_id).copy(new_subject_set_name='My New Subject Set')
 
-Other examples Programmatic Data Exports
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Programmatic Data Exports
+~~~~~~~~~~~~~~~~~~~~~~~~~
 The Panoptes Python Client allows you to generate, describe, and download data exports (e.g., classifications, subjects, workflows) via the Python ``panoptes_client`` library.
 
 Multiple types of exports can be generated using the Python Client, including project-level products (classifications, subjects, workflows) as smaller scale classification exports (for workflows and subject sets).

--- a/docs/user_guide.rst
+++ b/docs/user_guide.rst
@@ -383,7 +383,7 @@ Adding Subject Effect for a Subject Rule with id `1234` by Workflow. Ths particu
     workflow.add_caesar_rule_effect('subject', 1234, 'retire_subject', {'reason' : 'consensus'})
 
 Other examples Project Copier
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The project copier feature clones an existing template project (i.e., projects which have the project.configuration `template` flag set as true and are not live).
 
 You can set the template flag using the Project.save() method. See example below::
@@ -392,8 +392,8 @@ You can set the template flag using the Project.save() method. See example below
     project.configuration = {"template": True}
     project.save()
 
-How to use
-~~~~~~~~~~
+**How to use**
+
 This functionality can be accessed by the Panoptes python client. It exists on the Project module and can be called with the `copy` method::
 
     Project(project_id).copy()
@@ -409,8 +409,7 @@ The Panoptes Python Client allows you to generate, describe, and download data e
 Multiple types of exports can be generated using the Python Client, including project-level products (classifications, subjects, workflows) as smaller scale classification exports (for workflows and subject sets).
 For the examples below, we will demonstrate commands for a project wide classifications export, but these functions work for any export type.
 
-Get Exports
-~~~~~~~~~~~
+**Get Exports**
 
 As the name implies, this method downloads a data export over HTTP. This uses the `get_export` method and can be called by passing in the following parameters::
 
@@ -431,16 +430,16 @@ These wrappers take care of correctly decoding the export content for the CSV pa
     for row in classification_export.csv_dictreader():
     print(row)
 
-Generate Exports
-~~~~~~~~~~~~~~~
+**Generate Exports**
+
 As the name implies, this method generates/starts a data export. This uses the `generate_export` method and can be called by passing in the `export_type` parameter::
 
     export_info = Project(project_id).generate_export(export_type='classifications')
 
 This would return `export_info` as a dictionary containing the metadata on the selected export
 
-Wait Exports
-~~~~~~~~~~~~
+**Wait Exports**
+
 As the name implies, this method blocks/waits until an in-progress export is ready. It uses the `wait_export` method and can be called passing the following parameters::
 
     export_type #string specifying which type of export should be downloaded
@@ -451,8 +450,8 @@ As the name implies, this method blocks/waits until an in-progress export is rea
 
 This would return `export_info` as a dictionary containing the metadata on the selected export and throw a `PanoptesAPIException` once the time limit is exceeded and the export is not ready
 
-Describing Exports
-~~~~~~~~~~~~~~~~~~
+**Describing Exports**
+
 This method fetches information/metadata about a specific type of export. This uses the `describe_export` method and can be called by passing in the export_type(classifications, subject_sets) this way::
 
     export_info = Project(project_id).describe_export(export_type='classifications')


### PR DESCRIPTION
Adding docs for Project Copier & Programmatic Data Exports, and reorganizing "Other examples" section into individual TOC items.