### PR TITLE
Remove pkg_resources dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@
 #
 import datetime
 import os
-import pkg_resources
+import importlib.metadata
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
@@ -62,7 +62,7 @@ author = u'Zooniverse'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = pkg_resources.require("panoptes_client")[0].version
+release = importlib.metadata.version("panoptes_client")
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -6,7 +6,7 @@ import logging
 import os
 import requests
 import threading
-import pkg_resources
+import importlib.metadata
 
 from datetime import datetime, timedelta
 from redo import retrier
@@ -57,7 +57,7 @@ class Panoptes(object):
     _http_headers = {
         'default': {
             'Accept': 'application/vnd.api+json; version=1',
-            'User-Agent': 'panoptes-python-client/version=' + pkg_resources.require('panoptes_client')[0].version
+            'User-Agent': 'panoptes-python-client/version=' + importlib.metadata.version('panoptes_client')
         },
         'GET': {},
         'PUT': {

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -21,16 +21,16 @@ try:
     import magic
     MEDIA_TYPE_DETECTION = 'magic'
 except ImportError:
-    import pkg_resources
+    import importlib.metadata
     try:
-        pkg_resources.require("python-magic")
+        importlib.metadata.version("python-magic")
         logging.getLogger('panoptes_client').warn(
             'Broken libmagic installation detected. The python-magic module is'
             ' installed but can\'t be imported. Please check that both '
             'python-magic and the libmagic shared library are installed '
             'correctly. Uploading media other than images may not work.'
         )
-    except pkg_resources.DistributionNotFound:
+    except importlib.metadata.PackageNotFoundError:
         pass
     import imghdr
     MEDIA_TYPE_DETECTION = 'imghdr'


### PR DESCRIPTION
Closes #305 

Following recommendations from the `pkg_resources` devs, I'm replacing its use for extracting package versions by swapping in the `importlib.metadata` package.