### PR TITLE
Upload Subject Attached Media

### DIFF
--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -401,7 +401,6 @@ class Subject(PanoptesObject):
         async_save = hasattr(self._local, 'save_exec')
 
         with client:
-            import pdb; pdb.set_trace()
             metadata = metadata or {}
 
             try:

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -215,18 +215,19 @@ class Subject(PanoptesObject):
     def _detect_media_type(self, media_data=None, manual_mimetype=None):
         if manual_mimetype is not None:
             return manual_mimetype
+
         if MEDIA_TYPE_DETECTION == 'magic':
             return magic.from_buffer(media_data, mime=True)
-        else:
-            media_type = mimetypes.guess_type(media_data)[0]
-            if not media_type:
-                raise UnknownMediaException(
-                        'Could not detect file type. Please try installing '
-                        'libmagic: https://panoptes-python-client.readthedocs.'
-                        'io/en/latest/user_guide.html#uploading-non-image-'
-                        'media-types'
-                )
-            return 'image/{}'.format(media_type)
+
+        media_type = mimetypes.guess_type(media_data)[0]
+        if not media_type:
+            raise UnknownMediaException(
+                    'Could not detect file type. Please try installing '
+                    'libmagic: https://panoptes-python-client.readthedocs.'
+                    'io/en/latest/user_guide.html#uploading-non-image-'
+                    'media-types'
+            )
+        return media_type
 
     def _validate_media_type(self, media_type=None):
         if media_type not in ALLOWED_MIME_TYPES:
@@ -299,7 +300,7 @@ class Subject(PanoptesObject):
             media_data = f.read()
             media_type = self._detect_media_type(media_data, manual_mimetype)
 
-            self._validate_media_type(media_type=media_type)
+            self._validate_media_type(media_type)
 
             self.locations.append(media_type)
             self._media_files.append(media_data)

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -342,16 +342,19 @@ class Subject(PanoptesObject):
 
             return json_response['media'][0]['src']
 
-    def _save_attached_image(self, attached_media, client=None):
+    def _save_attached_image(self, attached_media, metadata=None, client=None):
         if not client:
             client = Panoptes.client()
 
         with client:
+            metadata = metadata or {}
+
             if type(attached_media) is dict:
                 for content_type, url in attached_media.items():
                     self.add_attached_image(
                         src=url,
                         content_type=content_type,
+                        metadata=metadata,
                         external_link=True,
                     )
                 return
@@ -369,25 +372,28 @@ class Subject(PanoptesObject):
             file_url = self.add_attached_image(
                 src=None,
                 content_type=media_type,
+                metadata=metadata,
                 external_link=False,
             )
             self._upload_media(file_url, media_data, media_type)
 
-    def save_attached_image(self,attached_media, client=None):
+    def save_attached_image(self,attached_media, metadata=None, client=None):
         """
-        Add a attached_media to this subject. This should not be confused with subject location.
+        Add a attached_media to this subject.
+        NOTE: This should NOT be confused with subject location.
         A subject location is the content of the subject that a volunteer will classify.
         A subject attached_media is ancillary data associated to the subject that get displayed on the Subject's Talk Page.
 
         - **attached_media** can be an open :py:class:`file` object, a path to a
           local file, or a :py:class:`dict` containing MIME types and URLs for
           remote media.
+        - **metadata** can be a :py:class:`dict` that stores additional info on attached_media.
 
         Examples::
 
             subject.save_attached_image(my_file)
             subject.save_attached_image('/data/image.jpg')
-            subject.save_attached_image({'image/png': 'https://example.com/image.png'})
+            subject.save_attached_image(my_file, {'metadata_test': 'Object 1'})
         """
         if not client:
             client = Panoptes.client()
@@ -396,6 +402,7 @@ class Subject(PanoptesObject):
 
         with client:
             import pdb; pdb.set_trace()
+            metadata = metadata or {}
 
             try:
                 if async_save:
@@ -407,6 +414,7 @@ class Subject(PanoptesObject):
                     self._save_attached_image,
                     args=(
                         attached_media,
+                        metadata,
                         client
                     ),
                     attempts=UPLOAD_RETRY_LIMIT,

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -228,6 +228,10 @@ class Subject(PanoptesObject):
                 )
             return 'image/{}'.format(media_type)
 
+    def _validate_media_type(self, media_type=None):
+        if media_type not in ALLOWED_MIME_TYPES:
+            raise UnknownMediaException(f"File type {media_type} is not allowed.")
+
     @property
     def async_save_result(self):
         """
@@ -295,8 +299,7 @@ class Subject(PanoptesObject):
             media_data = f.read()
             media_type = self._detect_media_type(media_data, manual_mimetype)
 
-            if media_type not in ALLOWED_MIME_TYPES:
-                raise UnknownMediaException(f"File type {media_type} is not allowed.")
+            self._validate_media_type(media_type=media_type)
 
             self.locations.append(media_type)
             self._media_files.append(media_data)
@@ -356,6 +359,7 @@ class Subject(PanoptesObject):
             try:
                 media_data = f.read()
                 media_type = self._detect_media_type(media_data, manual_mimetype)
+                self._validate_media_type(media_type)
             finally:
                 f.close()
             file_url = self.add_attached_image(

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -337,8 +337,7 @@ class Subject(PanoptesObject):
         with client:
             json_response, _ = self.http_post(
             '{}/attached_images'.format(self.id),
-            json={'media': media_data},
-        )
+            json={'media': media_data})
 
             return json_response['media'][0]['src']
 
@@ -408,7 +407,7 @@ class Subject(PanoptesObject):
                     upload_exec = self._local.save_exec
                 else:
                     upload_exec = ThreadPoolExecutor(max_workers=ASYNC_SAVE_THREADS)
-                upload_exec.submit(
+                future_result = upload_exec.submit(
                     retry,
                     self._save_attached_image,
                     args=(
@@ -423,6 +422,7 @@ class Subject(PanoptesObject):
                     ),
                     log_args=False,
                 )
+                return future_result.result()
             finally:
                 if not async_save:
                     # Shuts down and waits for the task if this isn't being used in a `async_saves` block

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -394,6 +394,7 @@ class Subject(PanoptesObject):
 
         async_save = hasattr(self._local, 'save_exec')
 
+        future_result = None
         with client:
             metadata = metadata or {}
 
@@ -418,11 +419,11 @@ class Subject(PanoptesObject):
                     ),
                     log_args=False,
                 )
-                return future_result.result()
             finally:
                 if not async_save:
                     # Shuts down and waits for the task if this isn't being used in a `async_saves` block
                     upload_exec.shutdown(wait=True)
+        return future_result
 
 
 class UnknownMediaException(Exception):


### PR DESCRIPTION
Upload Subject attached media/ attached images/ancillary data for existing subjects

Example usages: 

Without async
```
subject = Subject(1234)
local_files = [...]

for file_location in local_files: 
  future_result = subject.save_attached_image(file_location)
  try:
    future_result.result()
  except Exception e:
    print(f"Upload failed for {file_location}")
    print(e)
   
```

With async_saves
```
from concurrent.futures import as_completed

subject = Subject(1234)
local_files = [...]

with Subject.async_saves():
    future_to_file = {subject.save_attached_image(file_location): file_location for file_location in local_files}
    for future in concurrent.futures.as_completed(future_to_file):
        local_file = future_to_file[future]
        try:
            future.result()
        except Exception as exc:
            print(f"Upload failed for {local_file}")
```