### PR TITLE
Update Github Actions to most recent available stable versions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,11 +7,11 @@ jobs:
     name: Build python package and publish to PyPi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,17 +1,19 @@
 name: Publish to Test PyPi
 
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:
     name: Build python package and publish to Test PyPi
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5 # using v5 since ubuntu-latest currently does not support node 24 (v6 runs on 24)
       with:
-        python-version: '3.9'
+        python-version: '3.13' # 3.14 currently not found using v5 setup-python
         cache: 'pip' # caching pip dependencies
         cache-dependency-path: setup.py
     - name: Install dependencies


### PR DESCRIPTION
- Update actions/checkout to latest v6. (Publish to PyPi was using master, but actions/checkout repo moved away from master to main as main branch months back; run-tests was using v3)
- Update actions/setup-python to v5 (v6 is available HOWEVER needs a runner that supports node 24, currently ubuntu-latest does not support node 24; but that should change soon)
- Have actions run on Python 3.13 (3.14 currently not found when using setup-python@v5)

- Update Publish to Test PyPi to run on a published release, in order to sync releases on Github with releases on PyPI. **Note that in order to publish to PyPi is still done on workflow dispatch**