### PR TITLE
Update subject priority for sequential selection

### DIFF
--- a/panoptes_client/set_member_subject.py
+++ b/panoptes_client/set_member_subject.py
@@ -4,7 +4,9 @@ from panoptes_client.panoptes import PanoptesObject, LinkResolver
 class SetMemberSubject(PanoptesObject):
     _api_slug = 'set_member_subjects'
     _link_slug = 'set_member_subjects'
-    _edit_attributes = ()
+    _edit_attributes = (
+        'priority',
+    )
 
 LinkResolver.register(SetMemberSubject)
 LinkResolver.register(SetMemberSubject, 'set_member_subject')

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -467,7 +467,7 @@ class Subject(PanoptesObject):
                     # Shuts down and waits for the task if this isn't being used in a `async_saves` block
                     upload_exec.shutdown(wait=True)
         return future_result
-    
+
     def update_priority(self, priority, subject_set_id=None):
         """
         Update the priority of this subject in the subject set.

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -9,11 +9,10 @@ from panoptes_client.panoptes import (
 import mimetypes
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-import time
 import threading
 import requests
 import logging
-from builtins import range, str
+from builtins import str
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 from panoptes_client.set_member_subject import SetMemberSubject
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -1,3 +1,19 @@
+from redo import retry
+from panoptes_client.panoptes import (
+    LinkResolver,
+    ObjectNotSavedException,
+    Panoptes,
+    PanoptesAPIException,
+    PanoptesObject,
+)
+import mimetypes
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
+import time
+import threading
+import requests
+import logging
+from builtins import range, str
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
 from panoptes_client.set_member_subject import SetMemberSubject
 
@@ -7,16 +23,6 @@ try:
 except NameError:
     pass
 
-from builtins import range, str
-
-import logging
-import requests
-import threading
-import time
-
-from copy import deepcopy
-from concurrent.futures import ThreadPoolExecutor
-import mimetypes
 
 try:
     import magic
@@ -33,14 +39,6 @@ except ImportError:
         pass
     MEDIA_TYPE_DETECTION = 'mimetypes'
 
-from panoptes_client.panoptes import (
-    LinkResolver,
-    ObjectNotSavedException,
-    Panoptes,
-    PanoptesAPIException,
-    PanoptesObject,
-)
-from redo import retry
 
 UPLOAD_RETRY_LIMIT = 5
 RETRY_BACKOFF_INTERVAL = 5
@@ -58,6 +56,7 @@ ALLOWED_MIME_TYPES = [
     "text/plain",
     "application/json",
 ]
+
 
 class Subject(PanoptesObject):
     _api_slug = 'subjects'
@@ -233,7 +232,8 @@ class Subject(PanoptesObject):
 
     def _validate_media_type(self, media_type=None):
         if media_type not in ALLOWED_MIME_TYPES:
-            raise UnknownMediaException(f"File type {media_type} is not allowed.")
+            raise UnknownMediaException(
+                f"File type {media_type} is not allowed.")
 
     @property
     def async_save_result(self):
@@ -342,7 +342,8 @@ class Subject(PanoptesObject):
             client = Panoptes.client()
 
         with client:
-            json_response, _ = self.http_post('{}/attached_images'.format(self.id), json={'media': media_data})
+            json_response, _ = self.http_post(
+                '{}/attached_images'.format(self.id), json={'media': media_data})
 
             return json_response['media'][0]['src']
 
@@ -370,7 +371,8 @@ class Subject(PanoptesObject):
             media_type = None
             try:
                 media_data = f.read()
-                media_type = self._detect_media_type(media_data, manual_mimetype)
+                media_type = self._detect_media_type(
+                    media_data, manual_mimetype)
                 self._validate_media_type(media_type)
             finally:
                 f.close()
@@ -445,7 +447,8 @@ class Subject(PanoptesObject):
                 if async_save:
                     upload_exec = self._local.save_exec
                 else:
-                    upload_exec = ThreadPoolExecutor(max_workers=ASYNC_SAVE_THREADS)
+                    upload_exec = ThreadPoolExecutor(
+                        max_workers=ASYNC_SAVE_THREADS)
                 future_result = upload_exec.submit(
                     retry,
                     self._save_attached_image,
@@ -484,7 +487,7 @@ class Subject(PanoptesObject):
 
         if self.id is None:
             raise ObjectNotSavedException
-        
+
         self.metadata['priority'] = priority
         self.save()
 

--- a/panoptes_client/subject.py
+++ b/panoptes_client/subject.py
@@ -1,4 +1,5 @@
 from panoptes_client.subject_workflow_status import SubjectWorkflowStatus
+from panoptes_client.set_member_subject import SetMemberSubject
 
 _OLD_STR_TYPES = (str,)
 try:
@@ -466,6 +467,38 @@ class Subject(PanoptesObject):
                     # Shuts down and waits for the task if this isn't being used in a `async_saves` block
                     upload_exec.shutdown(wait=True)
         return future_result
+    
+    def update_priority(self, priority, subject_set_id=None):
+        """
+        Update the priority of this subject in the subject set.
+
+        If subject_set_id is not provided, the priority will be updated in all subject sets that this subject belongs to.
+
+        - **priority** is an integer value that represents the priority of the subject in the subject set.
+
+        Examples::
+
+            subject.update_priority(1)
+            subject.update_priority(2, subject_set_id=1234)
+        """
+
+        if self.id is None:
+            raise ObjectNotSavedException
+        
+        self.metadata['priority'] = priority
+        self.save()
+
+        if subject_set_id is not None:
+            subject_sets = [subject_set_id]
+        else:
+            subject_sets = [s.id for s in self.links.subject_sets]
+
+        for ss_id in subject_sets:
+            sms = next(SetMemberSubject.where(
+                subject_set_id=ss_id,
+                subject_id=self.id))
+            sms.priority = priority
+            sms.save()
 
 
 class UnknownMediaException(Exception):

--- a/panoptes_client/tests/test_subject.py
+++ b/panoptes_client/tests/test_subject.py
@@ -1,9 +1,10 @@
 import io
-import unittest
-from unittest.mock import patch, mock_open
-
-from panoptes_client.subject import Subject, UnknownMediaException
 import mimetypes
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+
+from panoptes_client.panoptes import ObjectNotSavedException
+from panoptes_client.subject import Subject, UnknownMediaException
 
 
 class TestSubject(unittest.TestCase):
@@ -39,7 +40,7 @@ class TestSubject(unittest.TestCase):
         self.assertIn("locations", self.subject.modified_attributes)
         mock_magic.from_buffer.assert_called_with(data, mime=True)
 
-    @patch.object(mimetypes, 'guess_type', return_value=("image/jpeg", None))
+    @patch("panoptes_client.subject.mimetypes.guess_type", return_value=("image/jpeg", None))
     def test_add_location_mimetypes_detection(self, mock_guess_type):
         import panoptes_client.subject as subject_module
         subject_module.MEDIA_TYPE_DETECTION = 'mimetypes'
@@ -57,3 +58,74 @@ class TestSubject(unittest.TestCase):
         fake_file = io.BytesIO(data)
         with self.assertRaises(UnknownMediaException):
             self.subject.add_location(fake_file, manual_mimetype="application/javascript")
+    
+    def test_update_priority_requires_saved_subject(self):
+        with self.assertRaises(ObjectNotSavedException):
+            self.subject.update_priority(1)
+
+    def test_update_priority_updates_priority_for_saved_subject(self):
+        self.subject.id = 123  
+        set_member_subject_mock = MagicMock()
+
+        with patch.object(self.subject, "save") as mock_save:
+            with patch(
+                "panoptes_client.subject.SetMemberSubject.where",
+                return_value=iter([set_member_subject_mock]),
+            ) as mock_where:
+                self.subject.update_priority(
+                    5,
+                    subject_set_id=456,
+                )
+
+        self.assertEqual(self.subject.metadata["priority"], 5)
+
+        mock_save.assert_called_once_with()
+        mock_where.assert_called_once_with(
+            subject_set_id=456,
+            subject_id=123,
+        )
+
+        self.assertEqual(set_member_subject_mock.priority, 5)
+        set_member_subject_mock.save.assert_called_once_with()
+    
+    def test_update_priority_updates_all_subject_sets(self):
+        self.subject.id = 123
+
+        subject_set_1 = MagicMock(id=456)
+        subject_set_2 = MagicMock(id=789)
+        set_member_subject_1 = MagicMock()
+        set_member_subject_2 = MagicMock()
+
+        with patch.object(self.subject, "save") as mock_save, \
+            patch(
+             "panoptes_client.panoptes.LinkResolver.__getattr__",
+             return_value=[subject_set_1, subject_set_2],
+            ),  \
+            patch(
+                "panoptes_client.subject.SetMemberSubject.where",
+                side_effect=[
+                    iter([set_member_subject_1]),
+                    iter([set_member_subject_2]),
+                ],
+            ) as mock_where:
+            self.subject.update_priority(5)
+
+        self.assertEqual(self.subject.metadata["priority"], 5)
+
+        mock_save.assert_called_once_with()
+
+        self.assertEqual(mock_where.call_count, 2)
+        mock_where.assert_any_call(
+            subject_set_id=456,
+            subject_id=123,
+        )
+        mock_where.assert_any_call(
+            subject_set_id=789,
+            subject_id=123,
+        )
+
+        self.assertEqual(set_member_subject_1.priority, 5)
+        set_member_subject_1.save.assert_called_once_with()
+
+        self.assertEqual(set_member_subject_2.priority, 5)
+        set_member_subject_2.save.assert_called_once_with()

--- a/panoptes_client/tests/test_subject.py
+++ b/panoptes_client/tests/test_subject.py
@@ -40,7 +40,7 @@ class TestSubject(unittest.TestCase):
         self.assertIn("locations", self.subject.modified_attributes)
         mock_magic.from_buffer.assert_called_with(data, mime=True)
 
-    @patch("panoptes_client.subject.mimetypes.guess_type", return_value=("image/jpeg", None))
+    @patch.object(mimetypes, 'guess_type', return_value=("image/jpeg", None))
     def test_add_location_mimetypes_detection(self, mock_guess_type):
         import panoptes_client.subject as subject_module
         subject_module.MEDIA_TYPE_DETECTION = 'mimetypes'

--- a/panoptes_client/tests/test_subject.py
+++ b/panoptes_client/tests/test_subject.py
@@ -58,7 +58,7 @@ class TestSubject(unittest.TestCase):
         fake_file = io.BytesIO(data)
         with self.assertRaises(UnknownMediaException):
             self.subject.add_location(fake_file, manual_mimetype="application/javascript")
-    
+
     def test_update_priority_requires_saved_subject(self):
         with self.assertRaises(ObjectNotSavedException):
             self.subject.update_priority(1)
@@ -87,7 +87,7 @@ class TestSubject(unittest.TestCase):
 
         self.assertEqual(set_member_subject_mock.priority, 5)
         set_member_subject_mock.save.assert_called_once_with()
-    
+
     def test_update_priority_updates_all_subject_sets(self):
         self.subject.id = 123
 

--- a/panoptes_client/tests/test_subject.py
+++ b/panoptes_client/tests/test_subject.py
@@ -57,14 +57,15 @@ class TestSubject(unittest.TestCase):
         data = b"fake data"
         fake_file = io.BytesIO(data)
         with self.assertRaises(UnknownMediaException):
-            self.subject.add_location(fake_file, manual_mimetype="application/javascript")
+            self.subject.add_location(
+                fake_file, manual_mimetype="application/javascript")
 
     def test_update_priority_requires_saved_subject(self):
         with self.assertRaises(ObjectNotSavedException):
             self.subject.update_priority(1)
 
     def test_update_priority_updates_priority_for_saved_subject(self):
-        self.subject.id = 123  
+        self.subject.id = 123
         set_member_subject_mock = MagicMock()
 
         with patch.object(self.subject, "save") as mock_save:
@@ -98,16 +99,16 @@ class TestSubject(unittest.TestCase):
 
         with patch.object(self.subject, "save") as mock_save, \
             patch(
-             "panoptes_client.panoptes.LinkResolver.__getattr__",
-             return_value=[subject_set_1, subject_set_2],
-            ),  \
+            "panoptes_client.panoptes.LinkResolver.__getattr__",
+            return_value=[subject_set_1, subject_set_2],
+        ),  \
             patch(
                 "panoptes_client.subject.SetMemberSubject.where",
                 side_effect=[
                     iter([set_member_subject_1]),
                     iter([set_member_subject_2]),
                 ],
-            ) as mock_where:
+        ) as mock_where:
             self.subject.update_priority(5)
 
         self.assertEqual(self.subject.metadata["priority"], 5)


### PR DESCRIPTION
Part of this panoptes issue: https://github.com/zooniverse/panoptes/issues/4582 

TL;DR of the issue is that when project teams want to set up sequential subject selection BUT did not upload `priority` within subject metadata on initial upload, Designator does not see updated `priority` when project team updates subject metadata. [Eg script of how project teams update subject metadata found here: https://github.com/zooniverse/Data-digging/blob/master/scripts_Utility/edit_metadata_indiv.py] Mainly because Designator looks at a Subject's corresponding SetMemberSubject to view priority. 

This change allows project teams a way to not only update subject metadata's priority but also the SetMemberSubject for Designator to show correct subject order.

### TESTING CHECKLIST 

- [x] Priority gets updated for both metadata and corresponding set_member_subject
- [x] As priority is updated for a workflow that uses sequential subject selection, Designator displays the correct subjects in priority order. 
 --- Note for ^ , workflow might need to be reloaded on Designator for subjects to show up in correct priority order.
(via authenticated POST to /api/workflows/:id/reload)

### TODO 

- [x] Example script on DataDigging repo (PR:  https://github.com/zooniverse/Data-digging/pull/66)